### PR TITLE
Bump to adventure release

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -63,8 +63,7 @@ tasks {
             "https://guava.dev/releases/${libs.guava.get().version}/api/docs/",
             "https://google.github.io/guice/api-docs/${libs.guice.get().version}/javadoc/",
             "https://docs.oracle.com/en/java/javase/17/docs/api/",
-            //"https://jd.advntr.dev/api/${libs.adventure.bom.get().version}/",
-            "https://jd.advntr.dev/api/4.14.0/",
+            "https://jd.advntr.dev/api/${libs.adventure.bom.get().version}/",
             "https://javadoc.io/doc/com.github.ben-manes.caffeine/caffeine"
         )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,8 +11,7 @@ shadow = "com.github.johnrengelman.shadow:8.1.0"
 spotless = "com.diffplug.spotless:6.12.0"
 
 [libraries]
-# See JD links in velocity-apo when moving to non-snapshot versions
-adventure-bom = "net.kyori:adventure-bom:4.15.0-SNAPSHOT"
+adventure-bom = "net.kyori:adventure-bom:4.15.0"
 adventure-facet = "net.kyori:adventure-platform-facet:4.3.0"
 asm = "org.ow2.asm:asm:9.5"
 brigadier = "com.velocitypowered:velocity-brigadier:1.0.0-SNAPSHOT"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,6 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         mavenCentral()
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") // adventure
         maven("https://repo.papermc.io/repository/maven-public/")
     }
 }


### PR DESCRIPTION
The API changes required for adopting resource packs are still needed, however the maven snapshots repo is dead, and nothing technically stops us from doing this