### PR TITLE
Fixed no-config-phase for 1.21.4 and 1.21.5

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -237,8 +237,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
     smc.getChannel().pipeline().get(MinecraftDecoder.class).setState(StateRegistry.PLAY);
 
-    if (server.getConfiguration().isEnableConfigurationPhase()
-            && player.getConnection().getActiveSessionHandler() instanceof ClientConfigSessionHandler configHandler) {
+    if (player.getConnection().getActiveSessionHandler() instanceof ClientConfigSessionHandler configHandler) {
       // Configuration phase is enabled — use original logic
       configHandler.handleBackendFinishUpdate(serverConn).thenRunAsync(() -> {
         smc.write(FinishedUpdatePacket.INSTANCE);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -165,12 +165,13 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
       if (player.getClientSettingsPacket() != null) {
         smc.write(player.getClientSettingsPacket());
       }
-      if (server.getConfiguration().isEnableConfigurationPhase()
-              && player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler clientPlaySessionHandler) {
+      MinecraftSessionHandler sessionHandler = player.getConnection().getActiveSessionHandler();
+      boolean doConfig = server.getConfiguration().isEnableConfigurationPhase()
+          || player.getProtocolVersion().greaterThan(ProtocolVersion.MINECRAFT_1_21_4);
+      if (doConfig && sessionHandler instanceof ClientPlaySessionHandler clientPlaySessionHandler) {
         smc.setAutoReading(false);
         clientPlaySessionHandler.doSwitch().thenAcceptAsync((unused) -> smc.setAutoReading(true), smc.eventLoop());
-      } else if (!server.getConfiguration().isEnableConfigurationPhase()
-              && !(player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler)) {
+      } else if (!(sessionHandler instanceof ClientPlaySessionHandler) && !doConfig) {
         // Initial login - the player is already in configuration state.
         server.getEventManager().fireAndForget(new PlayerEnteredConfigurationEvent(player, serverConn));
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -23,6 +23,7 @@ import com.velocitypowered.api.event.player.PlayerClientBrandEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerConfigurationEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerFinishConfigurationEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerFinishedConfigurationEvent;
+import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
@@ -171,7 +172,7 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(final KnownPacksPacket packet) {
-    if (server.getConfiguration().isEnableConfigurationPhase()) {
+    if (server.getConfiguration().isEnableConfigurationPhase() || player.getProtocolVersion().greaterThan(ProtocolVersion.MINECRAFT_1_21_4)) {
       if (player.getConnectionInFlightOrConnectedServer() != null) {
         callConfigurationEvent().thenRunAsync(() ->
                 player.getConnectionInFlightOrConnectedServer().ensureConnected().write(packet)).exceptionally(ex -> {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -749,7 +749,8 @@ public enum StateRegistry {
           map(0x5A, MINECRAFT_1_20_2, false),
           map(0x5C, MINECRAFT_1_20_3, false),
           map(0x5E, MINECRAFT_1_20_5, false),
-          map(0x64, MINECRAFT_1_21_2, false));
+          map(0x64, MINECRAFT_1_21_2, false)
+          map(0x63, MINECRAFT_1_21_5, false));
     }
   },
   LOGIN {


### PR DESCRIPTION
This is a bit of a blunt fix, but when disable-config-phase = true, it works fine for both 1.21.4 and 1.21.5 clients (where it is automatically disabled for 1.21.5 clients, because mojang apparently fixed the bug which has brought the purpose of this tweak in the first place)