### PR TITLE
Fixed NPE when switching from normal Velocity

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -256,7 +256,8 @@ public class VelocityCommandManager implements CommandManager {
       }
     } catch (final Throwable e) {
       // Ugly, ugly swallowing of everything Throwable, because plugins are naughty.
-      throw new RuntimeException("Unable to invoke command  " + parsed.getReader().getString() + "for " + source, e);
+      // "Ugly indeed, but with proper spacing... umm.. uhh... yeah still ugly..." - Hadimhz
+      throw new RuntimeException("Unable to invoke command " + parsed.getReader().getString() + " for " + source, e);
     } finally {
       eventManager.fireAndForget(new PostCommandInvocationEvent(source, parsed.getReader().getString(), result));
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
@@ -91,7 +91,8 @@ public final class ServerCommand {
                 return -1;
               }
 
-              if (this.server.getConfiguration().getQueue().getNoQueueServers().contains(registeredServer.getServerInfo().getName())
+              if (this.server.getConfiguration().getQueue().getNoQueueServers() == null
+                      || this.server.getConfiguration().getQueue().getNoQueueServers().contains(registeredServer.getServerInfo().getName())
                       || !server.getQueueManager().isQueueEnabled()
                       || player.hasPermission("velocity.queue.bypass")) {
                 player.createConnectionRequest(registeredServer).connectWithIndication();


### PR DESCRIPTION
Fixed NPE error which occurs when switching from Velo to Velo CTD
```
[16:26:12 INFO]: Exception occurred while running command for alt
java.util.concurrent.CompletionException: java.lang.RuntimeException: Unable to invoke command  server ValaticEventsfor [connected player] alt (/127.0.0.1:11460)
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.RuntimeException: Unable to invoke command  server ValaticEventsfor [connected player] alt (/127.0.0.1:11460)
        at com.velocitypowered.proxy.command.VelocityCommandManager.executeImmediately0(VelocityCommandManager.java:259) ~[proxy.jar:3.4.0-SNAPSHOT (git-f1ede829)]
        at com.velocitypowered.proxy.command.VelocityCommandManager.lambda$executeImmediatelyAsync$3(VelocityCommandManager.java:298) ~[proxy.jar:3.4.0-SNAPSHOT (git-f1ede829)]
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        ... 3 more
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.contains(Object)" because the return value of "com.velocitypowered.proxy.config.VelocityConfiguration$Queue.getNoQueueServers()" is null
        at com.velocitypowered.proxy.command.builtin.ServerCommand.lambda$register$2(ServerCommand.java:94) ~[proxy.jar:3.4.0-SNAPSHOT (git-f1ede829)]
        at com.velocitypowered.proxy.command.brigadier.VelocityBrigadierCommandWrapper.run(VelocityBrigadierCommandWrapper.java:61) ~[proxy.jar:3.4.0-SNAPSHOT (git-f1ede829)]
        at com.mojang.brigadier.CommandDispatcher.execute(CommandDispatcher.java:262) ~[proxy.jar:3.4.0-SNAPSHOT (git-f1ede829)]
        at com.velocitypowered.proxy.command.VelocityCommandManager.executeImmediately0(VelocityCommandManager.java:237) ~[proxy.jar:3.4.0-SNAPSHOT (git-f1ede829)]
        at com.velocitypowered.proxy.command.VelocityCommandManager.lambda$executeImmediatelyAsync$3(VelocityCommandManager.java:298) ~[proxy.jar:3.4.0-SNAPSHOT (git-f1ede829)]
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        ... 3 more
>
```


And fixed spacing issue with the catchall message:
`Unable to invoke command  server ValaticEventsfor [connected player] alt`
