### PR TITLE
fix: %bungee_total% placeholder to return Redis-enabled total player count

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -1605,12 +1605,18 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
   /**
    * Gets the number of players currently connected to the proxy.
+   * If Redis is enabled, this returns the total player count across all proxies.
+   * Otherwise, this returns only the local proxy's player count.
    *
    * @return the number of connected players
    */
   @Override
   public int getPlayerCount() {
-    return connectionsByUuid.size();
+    if (getMultiProxyHandler().isRedisEnabled()) {
+      return getMultiProxyHandler().getTotalPlayerCount();
+    } else {
+      return connectionsByUuid.size();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes the `%bungee_total%` placeholder to correctly display the total player count across all proxies when Redis is enabled.

## Problem
The `%bungee_total%` placeholder was only showing the local proxy's player count instead of the network-wide total in Redis-enabled multi-proxy setups.

## Solution
Modified `getPlayerCount()` method in `VelocityServer.java` to check if Redis is enabled and return `getMultiProxyHandler().getTotalPlayerCount()` when appropriate.

## Changes
- Updated `getPlayerCount()` to return Redis-enabled total when Redis is active
- Maintains backward compatibility for non-Redis setups
- Transparent to PlaceholderAPI and other plugins

Closes #443