### PR TITLE
ci: implement sequential build numbering system

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,11 +25,30 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
 
+    - name: Generate Release Tag
+      id: release_tag
+      run: |
+        # Get the latest build number from existing releases
+        LATEST_BUILD=0
+        
+        # Check if there are existing build tags and find the highest number
+        if git tag | grep -E "^build-[0-9]+$" > /dev/null; then
+          LATEST_BUILD=$(git tag | grep -E "^build-[0-9]+$" | sed 's/build-//' | sort -n | tail -1)
+        fi
+        
+        # Increment the build number
+        NEW_BUILD=$((LATEST_BUILD + 1))
+        
+        echo "tag=build-$NEW_BUILD" >> $GITHUB_OUTPUT
+        echo "Generated tag: build-$NEW_BUILD"
+        echo "Previous highest build: $LATEST_BUILD"
+        echo "New build number: $NEW_BUILD"
+
     - name: Upload Velocity
       uses: marvinpinto/action-automatic-releases@master
       with:
         title: "Velocity-CTD"
-        automatic_release_tag: "Releases"
+        automatic_release_tag: "${{ steps.release_tag.outputs.tag }}"
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         files: "*/build/libs/*.jar"
         prerelease: false


### PR DESCRIPTION
## Sequential Build Numbering System

This PR implements a new build numbering system that uses sequential build numbers for releases.

### How It Works:
1. The workflow scans existing tags for any matching `build-{number}` pattern
2. Finds the highest number using `sort -n | tail -1`
3. Increments by 1 to create the next build number
4. Handles the first build case (starts at `build-1` if no existing builds)

### Benefits:
- [x] Proper Release Ordering: Releases appear in correct chronological order
- [x] Clean Naming: Simple build numbers
- [x] No Conflicts: Each build gets a unique, sequential number
- [x] Easy Tracking: Clear progression of builds over time

Closes https://github.com/GemstoneGG/Velocity-CTD/issues/431