### PR TITLE
Add "/gkick" and "/ip" commands.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -1086,6 +1086,36 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       }
     }
 
+          if (configuration.isIPCommandEnabled() && !commandManager.hasCommand("ip")) {
+          List<String> aliases = configuration.getCommandAliases().getOrDefault("ip", List.of());
+          Command command = new IPCommand(this).register(true);
+          if (command != null) {
+              commandManager.register(
+                      commandManager.metaBuilder("ip")
+                              .aliases(aliases.toArray(String[]::new))
+                              .plugin(VelocityVirtualPlugin.INSTANCE)
+                              .build(),
+                      command
+              );
+          }
+      }
+
+      if (configuration.isGKickEnabled() && !commandManager.hasCommand("gkick")) {
+          List<String> aliases = configuration.getCommandAliases().getOrDefault("gkick", List.of());
+          Command command = new GKickCommand(this).register(true);
+          if (command != null) {
+              commandManager.register(
+                      commandManager.metaBuilder("gkick")
+                              .aliases(aliases.toArray(String[]::new))
+                              .plugin(VelocityVirtualPlugin.INSTANCE)
+                              .build(),
+                      command
+              );
+          }
+      }
+
+    
+
     for (Map.Entry<String, List<String>> entry : configuration.getSlashServers().entrySet()) {
       for (String alias : entry.getValue()) {
         new SlashServerCommand(this, entry.getKey()).register(alias);

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/GKickCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/GKickCommand.java
@@ -30,6 +30,7 @@ import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.VelocityCommands;
+import com.velocitypowered.proxy.redis.multiproxy.RemotePlayerInfo;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.translation.Argument;
@@ -67,6 +68,9 @@ public class GKickCommand {
     }
 
     private int kick(final CommandContext<CommandSource> context) {
+        if (server.getMultiProxyHandler().isRedisEnabled()) {
+            return findMultiProxy(context);
+        }
 
         final String player = context.getArgument("player", String.class);
         final Optional<Player> maybePlayer = server.getPlayer(player);
@@ -103,6 +107,43 @@ public class GKickCommand {
                 Component.translatable("velocity.command.gkick.message", NamedTextColor.YELLOW)
                         .arguments(
                                 Argument.string("player", p.getUsername())));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private int findMultiProxy(final CommandContext<CommandSource> context) {
+        final String player = context.getArgument("player", String.class);
+        if (server.getMultiProxyHandler().isPlayerOnline(player)) {
+            context.getSource().sendMessage(
+                    CommandMessages.PLAYER_NOT_FOUND.arguments(Argument.string("player", player))
+            );
+
+            return 0;
+        }
+
+        RemotePlayerInfo info = server.getMultiProxyHandler().getPlayerInfo(player);
+
+        if (info.getServerName() == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.gkick.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        RegisteredServer server = this.server.getServer(info.getServerName()).orElse(null);
+        if (server == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.gkick.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        context.getSource().sendMessage(
+                Component.translatable("velocity.command.gkick.message", NamedTextColor.YELLOW)
+                        .arguments(
+                                Argument.string("player", info.getName())));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/GKickCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/GKickCommand.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2018-2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.command.builtin;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.velocitypowered.api.command.BrigadierCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.command.VelocityCommands;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.translation.Argument;
+
+import java.util.Optional;
+
+/**
+ * Implements Velocity's {@code /gkick} command.
+ */
+public class GKickCommand {
+
+    private final VelocityServer server;
+
+    public GKickCommand(final VelocityServer server) {
+        this.server = server;
+    }
+
+    public BrigadierCommand register(final boolean isGKickEnabled) {
+        if (!isGKickEnabled) {
+            return null;
+        }
+
+        final LiteralArgumentBuilder<CommandSource> rootNode = BrigadierCommand
+                .literalArgumentBuilder("gkick")
+                .requires(source ->
+                        source.getPermissionValue("velocity.command.gkick") == Tristate.TRUE)
+                .executes(ctx -> VelocityCommands.emitUsage(ctx, "gkick"));
+        final RequiredArgumentBuilder<CommandSource, String> playerNode = BrigadierCommand
+                .requiredArgumentBuilder("player", StringArgumentType.word())
+                .suggests((ctx, builder) -> VelocityCommands.suggestPlayer(server, ctx, builder, true))
+                .executes(this::kick);
+
+        rootNode.then(playerNode);
+        return new BrigadierCommand(rootNode);
+    }
+
+    private int kick(final CommandContext<CommandSource> context) {
+
+        final String player = context.getArgument("player", String.class);
+        final Optional<Player> maybePlayer = server.getPlayer(player);
+        if (maybePlayer.isEmpty()) {
+            context.getSource().sendMessage(
+                    CommandMessages.PLAYER_NOT_FOUND.arguments(Argument.string("player", player))
+            );
+
+            return 0;
+        }
+
+        Player p = maybePlayer.get();
+        ServerConnection connection = p.getCurrentServer().orElse(null);
+        if (connection == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.gkick.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        RegisteredServer server = connection.getServer();
+        if (server == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.gkick.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        p.disconnect(Component.translatable("velocity.command.gkick.reason"));
+
+        context.getSource().sendMessage(
+                Component.translatable("velocity.command.gkick.message", NamedTextColor.YELLOW)
+                        .arguments(
+                                Argument.string("player", p.getUsername())));
+
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/IPCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/IPCommand.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2018-2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.command.builtin;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.velocitypowered.api.command.BrigadierCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.command.VelocityCommands;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.translation.Argument;
+
+import java.util.Optional;
+
+/**
+ * Implements Velocity's {@code /ip} command.
+ */
+public class IPCommand {
+
+    private final VelocityServer server;
+
+    public IPCommand(final VelocityServer server) {
+        this.server = server;
+    }
+
+    public BrigadierCommand register(final boolean isIPCommandEnabled) {
+        if (!isIPCommandEnabled) {
+            return null;
+        }
+
+        final LiteralArgumentBuilder<CommandSource> rootNode = BrigadierCommand
+                .literalArgumentBuilder("ip")
+                .requires(source ->
+                        source.getPermissionValue("velocity.command.ip") == Tristate.TRUE)
+                .executes(ctx -> VelocityCommands.emitUsage(ctx, "ip"));
+        final RequiredArgumentBuilder<CommandSource, String> playerNode = BrigadierCommand
+                .requiredArgumentBuilder("player", StringArgumentType.word())
+                .suggests((ctx, builder) -> VelocityCommands.suggestPlayer(server, ctx, builder, true))
+                .executes(this::get_ip_address);
+
+        rootNode.then(playerNode);
+        return new BrigadierCommand(rootNode);
+    }
+
+    private int get_ip_address(final CommandContext<CommandSource> context) {
+
+        final String player = context.getArgument("player", String.class);
+        final Optional<Player> maybePlayer = server.getPlayer(player);
+        if (maybePlayer.isEmpty()) {
+            context.getSource().sendMessage(
+                    CommandMessages.PLAYER_NOT_FOUND.arguments(Argument.string("player", player))
+            );
+
+            return 0;
+        }
+
+        Player p = maybePlayer.get();
+        ServerConnection connection = p.getCurrentServer().orElse(null);
+        if (connection == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.ip.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        RegisteredServer server = connection.getServer();
+        if (server == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.ip.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        context.getSource().sendMessage(
+                Component.translatable("velocity.command.ip.message", NamedTextColor.YELLOW)
+                        .arguments(
+                                Argument.string("player", p.getUsername()),
+                                Argument.string("ip_address", p.getRemoteAddress().getAddress().getHostAddress())));
+
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/IPCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/IPCommand.java
@@ -30,6 +30,7 @@ import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.VelocityCommands;
+import com.velocitypowered.proxy.redis.multiproxy.RemotePlayerInfo;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.translation.Argument;
@@ -102,6 +103,44 @@ public class IPCommand {
                         .arguments(
                                 Argument.string("player", p.getUsername()),
                                 Argument.string("ip_address", p.getRemoteAddress().getAddress().getHostAddress())));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private int findMultiProxy(final CommandContext<CommandSource> context) {
+        final String player = context.getArgument("player", String.class);
+        if (server.getMultiProxyHandler().isPlayerOnline(player)) {
+            context.getSource().sendMessage(
+                    CommandMessages.PLAYER_NOT_FOUND.arguments(Argument.string("player", player))
+            );
+
+            return 0;
+        }
+
+        RemotePlayerInfo info = server.getMultiProxyHandler().getPlayerInfo(player);
+
+        if (info.getServerName() == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.ip.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        RegisteredServer server = this.server.getServer(info.getServerName()).orElse(null);
+        if (server == null) {
+            context.getSource().sendMessage(
+                    Component.translatable("velocity.command.ip.no-server", NamedTextColor.YELLOW)
+            );
+
+            return 0;
+        }
+
+        context.getSource().sendMessage(
+                Component.translatable("velocity.command.ip.message", NamedTextColor.YELLOW)
+                        .arguments(
+                                Argument.string("player", info.getUsername()),
+                                Argument.string("ip_address", server.getServerInfo().getAddress().toString())));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -812,6 +812,24 @@ public final class VelocityConfiguration implements ProxyConfig {
     return commands.isSendEnabled();
   }
 
+      /**
+     * Returns whether the <code>/ip</code> command is enabled.
+     *
+     * @return {@code true} if enabled
+     * */
+    public boolean isIPCommandEnabled() {
+        return commands.isIPCommandEnabled();
+    }
+
+    /**
+     * Returns whether the <code>/gkick</code> command is enabled.
+     *
+     * @return {@code true} if enabled
+     * */
+    public boolean isGKickEnabled() {
+        return commands.isGKickEnabled();
+    }
+
   /**
    * Returns whether command usage should override the default <code>/server</code> help.
    *
@@ -1905,6 +1923,20 @@ public final class VelocityConfiguration implements ProxyConfig {
     @Expose
     private boolean findCommand = true;
 
+          /**
+       * Whether the /ip command is enabled.
+       * Lets users retrieve the IP address of a player.
+       */
+      @Expose
+      private boolean ipCommand = true;
+
+      /**
+       * Whether the /gkick command is enabled.
+       * Lets users kick players from the proxy.
+       */
+      @Expose
+      private boolean gkickCommand = true;
+
     /**
      * Whether the /glist command is enabled.
      * Displays a list of all online players across all servers.
@@ -1988,6 +2020,14 @@ public final class VelocityConfiguration implements ProxyConfig {
       return findCommand;
     }
 
+        public boolean isIPCommandEnabled() {
+          return ipCommand;
+      }
+
+      public boolean isGKickEnabled() {
+          return gkickCommand;
+      }
+
     public boolean isGlistEnabled() {
       return glistCommand;
     }
@@ -2028,6 +2068,8 @@ public final class VelocityConfiguration implements ProxyConfig {
           + ", hubCommand=" + hubCommand
           + ", pingCommand=" + pingCommand
           + ", sendCommand=" + sendCommand
+          + ", ipCommand=" + ipCommand
+          + ", gkickCommand=" + gkickCommand
           + ", overrideServerCommandUsage=" + overrideServerCommandUsage
           + '}';
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -1999,6 +1999,8 @@ public final class VelocityConfiguration implements ProxyConfig {
         this.hubCommand = config.getOrElse("hub-enabled", true);
         this.pingCommand = config.getOrElse("ping-enabled", true);
         this.sendCommand = config.getOrElse("send-enabled", true);
+        this.ipCommand = config.getOrElse("ip-command-enabled", true);
+        this.gkickCommand = config.getOrElse("gkick-enabled", true);
         this.overrideServerCommandUsage = config.getOrElse("override-server-command-usage", false);
         this.transferEnabled = config.getOrElse("transfer-enabled", true);
       }

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -123,6 +123,13 @@ velocity.command.transfer.invalid-version=<red><arg:0> cannot be transferred sin
 velocity.command.hub.fallback-connecting=<yellow>You are connecting to <green><arg:0><yellow>...
 velocity.command.hub.fallback-already-connected=<red>You are already connected to the fallback server <arg:0>!
 velocity.command.server.usage=<red>/<arg:0> <server>
+velocity.command.ip.usage=<red>/<arg:0> <player>
+velocity.command.ip.no-server=<red>That specified player is not currently online.
+velocity.command.ip.message=<red><arg:0> <white>is currently connected to <red><arg:1><white>.
+velocity.command.gkick.usage=<red>/<arg:0> <player>
+velocity.command.gkick.no-server=<red>That specified player is not currently online.
+velocity.command.gkick.message=<red><arg:0> <white>has been kicked.
+velocity.command.gkick.reason=<white>Kicked by an operator.
 # Kick
 velocity.kick.shutdown=<white>Proxy shutting down.
 # Rate Limiting

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -145,6 +145,8 @@ hub-enabled = true
 ping-enabled = true
 plist-enabled = true
 transfer-enabled = true
+ip-command-enabled = true
+gkick-enabled = true
 
 # Whether to use the default "/server" output, or whether to override it with the "velocity.command.server.usage" key.
 override-server-command-usage = false


### PR DESCRIPTION
I would like to suggest the addition of two new commands for Velocity-CTD: "/gkick" and "/ip".

Both of these commands originate from BungeeCord. The "/ip" command provides a quick way to retrieve a player's IP address, which can be very useful.

The "/gkick" command would also provide a way to kick a player from anywhere on the network.