### PR TITLE
Fix no queue servers for upgrading velocity users

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2945,7 +2945,7 @@ public final class VelocityConfiguration implements ProxyConfig {
      * @return a list of server names
      */
     public List<String> getNoQueueServers() {
-      return noQueueServers;
+      return noQueueServers == null ? java.util.Collections.emptyList() : noQueueServers;
     }
 
     /**


### PR DESCRIPTION
When velocity users upgrade to Velocity-CTD no queue servers is null by default and this version returns a empty list by default instead.