### PR TITLE
Consider different forwarding still same server for ServerInfo

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/server/ServerInfo.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/ServerInfo.java
@@ -107,8 +107,7 @@ public final class ServerInfo implements Comparable<ServerInfo> {
     }
 
     return Objects.equals(name, that.name)
-        && Objects.equals(address, that.address)
-        && Objects.equals(forwardingMode, that.forwardingMode);
+        && Objects.equals(address, that.address);
   }
 
   @Override


### PR DESCRIPTION
Users are not able to register servers via plugins when CTD is installed, this reverts the changes affecting comparison of servers during register of new servers.