### PR TITLE
Explicitly disable mouse support on the builder

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -135,6 +135,8 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
   protected LineReader buildReader(final LineReaderBuilder builder) {
     return super.buildReader(builder
         .appName("Velocity")
+        // Explicitly disable mouse support on the builder
+        .option(LineReader.Option.MOUSE, false)
         .completer((reader, parsedLine, list) -> {
           try {
             List<String> offers = this.server.getCommandManager()


### PR DESCRIPTION
Fixes https://github.com/GemstoneGG/Velocity-CTD/issues/692 (hopefully) by explicitly disabling mouse tracking

The issue is probably caused because of the update of the jline library

I recommend the person having the issue try this pr and see if the issue was resolved, tho it shouldnt hurt to have this option as we never use mouse for anything