### PR TITLE
Replace default "help" alias to "examplealias"

### DIFF
--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -204,7 +204,7 @@ hub = [
 # This is similar to Bukkit's commands.yml functionality.
 #
 # Adding multiple aliases executes multiple commands.
-help = [
+examplealias = [
     "velocity help"
 ]
 


### PR DESCRIPTION
Server owners are confused why their help commands are not being processed