### PR TITLE
Modern Forwarding for 1.7.2 - 1.12.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ native/zlib-ng
 native/zlib-cf
 native/libdeflate
 native/src/main/resources/linux_x86_64/velocity-cipher.so
+/.vs

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -2452,11 +2452,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
     // Check if the server uses modern forwarding and the client is too old
     PlayerInfoForwarding serverForwardingMode = ((VelocityRegisteredServer) server).getConfiguredPlayerInfoForwarding();
-    if (serverForwardingMode == PlayerInfoForwarding.MODERN && clientProtocolVersion.lessThan(ProtocolVersion.MINECRAFT_1_13)) {
+    if (serverForwardingMode == PlayerInfoForwarding.MODERN && clientProtocolVersion.lessThan(ProtocolVersion.MINECRAFT_1_7_2)) {
       // Disconnect the player with an appropriate message
       disconnect(Component.translatable("velocity.error.modern-forwarding-needs-new-client", NamedTextColor.RED)
           .arguments(
-              Argument.string("min", "1.13"),
+              Argument.string("min", "1.7.2"),
               Argument.string("max", ProtocolVersion.MAXIMUM_VERSION.getMostRecentSupportedVersion())));
       return true;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -235,7 +235,7 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
 
     // Determine if we're using Forge (1.8 to 1.12, may not be the case in 1.13).
     if (handshake.getServerAddress().endsWith(LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN)
-        && handshake.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_13)) {
+            && handshake.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_7_2)) { 
       return ConnectionTypes.LEGACY_FORGE;
     } else if (handshake.getProtocolVersion().noGreaterThan(ProtocolVersion.MINECRAFT_1_7_6)) {
       // 1.7 Forge will not notify us during handshake. UNDETERMINED will listen for incoming

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -839,7 +839,7 @@ public enum StateRegistry {
           map(0x01, MINECRAFT_1_7_2, false));
       serverbound.register(
           LoginPluginResponsePacket.class, LoginPluginResponsePacket::new,
-          map(0x02, MINECRAFT_1_13, false));
+          map(0x02, MINECRAFT_1_7_2, false));
       serverbound.register(
           LoginAcknowledgedPacket.class, LoginAcknowledgedPacket::new,
           map(0x03, MINECRAFT_1_20_2, false));
@@ -862,7 +862,7 @@ public enum StateRegistry {
       clientbound.register(
           LoginPluginMessagePacket.class,
           LoginPluginMessagePacket::new,
-          map(0x04, MINECRAFT_1_13, false));
+          map(0x04, MINECRAFT_1_7_2, false));
       clientbound.register(
           ClientboundCookieRequestPacket.class, ClientboundCookieRequestPacket::new,
           map(0x05, MINECRAFT_1_20_5, false));


### PR DESCRIPTION
Allow 1.7.2 - 1.12.2 to use modern forwarding
The mod https://github.com/adde0109/Proxy-Compatible-Forge Handles the forwarding

This pull request just edits the code to remove blocks that limit modern forwarding to 1.13+