### PR TITLE
Fix: Downgrade SnakeYAML to 1.33 to restore Floodgate MySQL connector…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ netty-transport-native-kqueue = { module = "io.netty:netty-transport-native-kque
 netty-transport-native-iouring = { module = "io.netty:netty-transport-native-io_uring", version.ref = "netty" }
 nightconfig = "com.electronwill.night-config:toml:3.8.3"
 slf4j = "org.slf4j:slf4j-api:2.0.17"
-snakeyaml = "org.yaml:snakeyaml:2.6"
+snakeyaml = "org.yaml:snakeyaml:1.33"
 spotbugs-annotations = "com.github.spotbugs:spotbugs-annotations:4.9.8"
 terminalconsoleappender = "net.minecrell:terminalconsoleappender:1.3.0"
 


### PR DESCRIPTION
SnakeYAML 2.X removed CustomClassLoaderConstructor(ClassLoader) causing NoSuchMethodError...
```yml
1) [Guice/ErrorInjectingMethod]: NoSuchMethodError: 'void CustomClassLoaderConstructor.<init>(ClassLoader)'
  at DatabaseConfigLoader.init(DatabaseConfigLoader.java:61)
  while locating DatabaseConfigLoader
```