### PR TITLE
Fix for multiple issues in the CTD rewrite

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/GkickCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/GkickCommand.java
@@ -31,6 +31,7 @@ import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.VelocityCommands;
 import com.velocitypowered.proxy.command.builtin.BuiltinCommand;
+import com.velocitypowered.proxy.command.builtin.CommandMessages;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.translation.Argument;
@@ -92,9 +93,7 @@ public class GkickCommand implements BuiltinCommand {
     final ConnectedPlayer player = server.getPlayer(playerName).orElse(null);
 
     if (player == null) {
-      context.getSource().sendMessage(
-          Component.translatable("velocity.command.gkick.no-server")
-      );
+      context.getSource().sendMessage(CommandMessages.PLAYER_NOT_FOUND);
       return 0;
     }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/HubCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/HubCommand.java
@@ -17,7 +17,6 @@
 
 package com.velocityctd.proxy.commands.builtin;
 
-
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.velocitypowered.api.command.BrigadierCommand;

--- a/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/HubCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/HubCommand.java
@@ -17,7 +17,6 @@
 
 package com.velocityctd.proxy.commands.builtin;
 
-import static java.util.Objects.requireNonNull;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
@@ -70,10 +69,16 @@ public class HubCommand implements BuiltinCommand {
     }
 
     VelocityServerConnection con = player.getCurrentServer().orElse(null);
-    requireNonNull(con);
+    if (con == null) {
+      player.sendMessage(Component.translatable("velocity.command.no-fallbacks"));
+      return 0;
+    }
 
     VelocityRegisteredServer currentServer = con.getServer();
-    requireNonNull(currentServer);
+    if (currentServer == null) {
+      player.sendMessage(Component.translatable("velocity.command.no-fallbacks"));
+      return 0;
+    }
 
     List<String> serversToTry = FallbackServerResolver.resolveServersToTry(server, player);
     if (serversToTry.contains(currentServer.getServerInfo().getName())) {
@@ -83,7 +88,10 @@ public class HubCommand implements BuiltinCommand {
     }
 
     ConnectedPlayer connectedPlayer = currentServer.getPlayer(player.getUniqueId());
-    requireNonNull(connectedPlayer);
+    if (connectedPlayer == null) {
+      player.sendMessage(Component.translatable("velocity.command.no-fallbacks"));
+      return 0;
+    }
 
     VelocityRegisteredServer nextServer = connectedPlayer.currentServerRetrySession().getNextServerToTry().orElse(null);
     if (nextServer == null) {

--- a/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/QueueAdminCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/QueueAdminCommand.java
@@ -288,7 +288,7 @@ public class QueueAdminCommand implements BuiltinCommand {
                   ctx.getSource().sendMessage(builder.build());
                 });
       }
-      return -1;
+      return Command.SINGLE_SUCCESS;
     } else if (server == null) {
       ctx.getSource().sendMessage(Component.translatable("velocity.command.server-does-not-exist")
               .arguments(Component.text(serverName)));
@@ -299,9 +299,8 @@ public class QueueAdminCommand implements BuiltinCommand {
 
     if (this.server.getConfiguration().getQueue().getNoQueueServers().contains(server.getServerInfo().getName())) {
       String newName = serverName;
-      if (serverName.equalsIgnoreCase("current")) {
-        VelocityServerConnection conn = ((ConnectedPlayer) ctx.getSource())
-            .getCurrentServer().orElse(null);
+      if (serverName.equalsIgnoreCase("current") && ctx.getSource() instanceof ConnectedPlayer cp) {
+        VelocityServerConnection conn = cp.getCurrentServer().orElse(null);
         if (conn != null) {
           newName = conn.getServerInfo().getName();
         }
@@ -346,27 +345,20 @@ public class QueueAdminCommand implements BuiltinCommand {
     VelocityQueue queue = server.getQueue();
     String serverName = server.getServerInfo().getName();
     if (queue.getState() == QueueState.PAUSED) {
-      queue.setState(QueueState.ACTIVE);
-
-      ctx.getSource().sendMessage(Component.translatable("velocity.queue.command.unpause")
+      ctx.getSource().sendMessage(Component.translatable("velocity.queue.error.already-paused")
               .arguments(Component.text(serverName)));
-
-      queue.broadcastMessage(
-          q -> Component.translatable("velocity.queue.command.unpaused")
-              .arguments(Component.text(serverName))
-      );
-      return Command.SINGLE_SUCCESS;
-    } else {
-      queue.setState(QueueState.PAUSED);
-
-      ctx.getSource().sendMessage(Component.translatable("velocity.queue.command.pause")
-              .arguments(Component.text(serverName)));
-
-      queue.broadcastMessage(
-          q -> Component.translatable("velocity.queue.command.paused")
-              .arguments(Component.text(serverName))
-      );
+      return -1;
     }
+
+    queue.setState(QueueState.PAUSED);
+
+    ctx.getSource().sendMessage(Component.translatable("velocity.queue.command.pause")
+            .arguments(Component.text(serverName)));
+
+    queue.broadcastMessage(
+        q -> Component.translatable("velocity.queue.command.paused")
+            .arguments(Component.text(serverName))
+    );
 
     return Command.SINGLE_SUCCESS;
   }
@@ -637,18 +629,10 @@ public class QueueAdminCommand implements BuiltinCommand {
 
     String playerName = ctx.getArgument("player", String.class);
 
-    if (this.server.isRedisEnabled()) {
-      if (!this.server.getRedis().getPlayerService().isPlayerOnline(playerName)) {
-        ctx.getSource().sendMessage(Component.translatable("velocity.command.player-not-found")
-                .arguments(Argument.string("player", playerName)));
-        return -1;
-      }
-    } else {
-      if (this.server.getPlayer(playerName).isEmpty()) {
-        ctx.getSource().sendMessage(Component.translatable("velocity.command.player-not-found")
-                .arguments(Argument.string("player", playerName)));
-        return -1;
-      }
+    if (this.server.getPlayer(playerName).isEmpty()) {
+      ctx.getSource().sendMessage(Component.translatable("velocity.command.player-not-found")
+              .arguments(Argument.string("player", playerName)));
+      return -1;
     }
 
     List<VelocityRegisteredServer> servers;
@@ -706,18 +690,10 @@ public class QueueAdminCommand implements BuiltinCommand {
   private int removeRedis(CommandContext<CommandSource> ctx) {
     String playerName = ctx.getArgument("player", String.class);
 
-    if (this.server.isRedisEnabled()) {
-      if (!this.server.getRedis().getPlayerService().isPlayerOnline(playerName)) {
-        ctx.getSource().sendMessage(Component.translatable("velocity.command.player-not-found")
-                .arguments(Argument.string("player", playerName)));
-        return -1;
-      }
-    } else {
-      if (this.server.getPlayer(playerName).isEmpty()) {
-        ctx.getSource().sendMessage(Component.translatable("velocity.command.player-not-found")
-                .arguments(Argument.string("player", playerName)));
-        return -1;
-      }
+    if (!this.server.getRedis().getPlayerService().isPlayerOnline(playerName)) {
+      ctx.getSource().sendMessage(Component.translatable("velocity.command.player-not-found")
+              .arguments(Argument.string("player", playerName)));
+      return -1;
     }
 
     List<VelocityRegisteredServer> servers;

--- a/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/SlashServerCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/SlashServerCommand.java
@@ -25,6 +25,7 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.VelocityCommands;
 import com.velocitypowered.proxy.command.builtin.BuiltinCommand;
+import com.velocitypowered.proxy.command.builtin.CommandMessages;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
@@ -67,7 +68,10 @@ public class SlashServerCommand implements BuiltinCommand {
   }
 
   private int send(CommandContext<CommandSource> ctx) {
-    ConnectedPlayer player = (ConnectedPlayer) ctx.getSource();
+    if (!(ctx.getSource() instanceof ConnectedPlayer player)) {
+      ctx.getSource().sendMessage(CommandMessages.PLAYERS_ONLY);
+      return -1;
+    }
 
     VelocityServerConnection connection = player.getCurrentServer().orElse(null);
     if (connection != null && connection.getServer() == registeredServer) {

--- a/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/TransferCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/TransferCommand.java
@@ -115,8 +115,8 @@ public class TransferCommand implements BuiltinCommand {
                     .executes(ctx -> VelocityCommands.emitUsage(ctx, label()))
                     .then(BrigadierCommand.requiredArgumentBuilder("proxy-id", StringArgumentType.word())
                             .suggests((ctx, builder) -> {
-                              String argument = ctx.getArguments().containsKey("proxy")
-                                      ? ctx.getArgument("proxy", String.class)
+                              String argument = ctx.getArguments().containsKey("proxy-id")
+                                      ? ctx.getArgument("proxy-id", String.class)
                                       : "";
                               for (ProxyAddress address : server.getConfiguration().getProxyAddresses()) {
                                 if (address.proxyId().regionMatches(true, 0, argument, 0, argument.length())) {

--- a/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/TransferCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/commands/builtin/TransferCommand.java
@@ -114,17 +114,7 @@ public class TransferCommand implements BuiltinCommand {
                     })
                     .executes(ctx -> VelocityCommands.emitUsage(ctx, label()))
                     .then(BrigadierCommand.requiredArgumentBuilder("proxy-id", StringArgumentType.word())
-                            .suggests((ctx, builder) -> {
-                              String argument = ctx.getArguments().containsKey("proxy-id")
-                                      ? ctx.getArgument("proxy-id", String.class)
-                                      : "";
-                              for (ProxyAddress address : server.getConfiguration().getProxyAddresses()) {
-                                if (address.proxyId().regionMatches(true, 0, argument, 0, argument.length())) {
-                                  builder.suggest(address.proxyId());
-                                }
-                              }
-                              return builder.buildFuture();
-                            })
+                            .suggests(VelocityCommands.suggestProxy(server, "proxy-id"))
                             .executes(this::transfer)))
             .build();
 

--- a/proxy/src/main/java/com/velocityctd/proxy/permission/PermissionResolverAdapterFactory.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/permission/PermissionResolverAdapterFactory.java
@@ -141,13 +141,15 @@ public final class PermissionResolverAdapterFactory {
       Runtime.getRuntime().addShutdownHook(new Thread(() -> {
         try {
           loader.close();
-        } catch (IOException ignored) {
+        } catch (IOException exception) {
+          throw new RuntimeException(exception);
         }
       }));
     } else {
       try {
         loader.close();
-      } catch (IOException ignored) {
+      } catch (IOException exception) {
+        throw new RuntimeException(exception);
       }
     }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/permission/PermissionResolverAdapterFactory.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/permission/PermissionResolverAdapterFactory.java
@@ -54,6 +54,7 @@ public final class PermissionResolverAdapterFactory {
 
   private static volatile boolean hasLoadedProvider = false;
   private static volatile @Nullable PermissionResolverProvider cachedProvider = null;
+  private static volatile @Nullable PluginClassLoader integrationLoader = null;
 
   private PermissionResolverAdapterFactory() {
   }
@@ -127,13 +128,30 @@ public final class PermissionResolverAdapterFactory {
       return Optional.empty();
     }
 
-    ClassLoader integrationLoader = new PluginClassLoader(new URL[] {jarUrl});
+    PluginClassLoader loader = new PluginClassLoader(new URL[] {jarUrl});
 
-    return ServiceLoader.load(PermissionResolverProvider.class, integrationLoader)
+    Optional<PermissionResolverProvider> provider = ServiceLoader.load(PermissionResolverProvider.class, loader)
         .stream()
         .map(ServiceLoader.Provider::get)
         .filter(PermissionResolverProvider::isAvailable)
         .findFirst();
+
+    if (provider.isPresent()) {
+      integrationLoader = loader;
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        try {
+          loader.close();
+        } catch (IOException ignored) {
+        }
+      }));
+    } else {
+      try {
+        loader.close();
+      } catch (IOException ignored) {
+      }
+    }
+
+    return provider;
   }
 
   /**

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
@@ -162,6 +162,7 @@ public final class RedisVelocityQueueManager extends VelocityQueueManager {
    * also re-broadcasts all server statuses and queue states so non-master proxies recover.</p>
    */
   private void reloadFromRedis() {
+    queues.clear();
     loadFromRedis();
 
     if (isMasterProxy()) {


### PR DESCRIPTION
Hi, I’ve fixed several minor issues whilst reviewing the new CTD rewrite

- HubCommand: Replaced `requireNonNull` with proper null checks for a nullable value to prevent an NPE if a player is not yet connected to a server
- GkickCommand: Used the correct message key for ‘player not found’ errors (`no-player` instead of `no-server`)
- TransferCommand: Corrected the incorrect argument key `"proxy"` -> `"proxy-id"` in the tab completion suggestions, which previously caused the suggestions to always fall back to an empty string
- PermissionResolverAdapterFactory: Close `PluginClassLoader` after use to prevent a leak of file descriptors and class loaders

And a few other things. This version is already live on the fablesmp.net network and works excellent