### PR TITLE
Merge `dev` branch into `libdeflate`

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/redis/impl/depot/PlayerDepotService.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/impl/depot/PlayerDepotService.java
@@ -20,6 +20,7 @@ package com.velocityctd.proxy.redis.impl.depot;
 import com.velocityctd.proxy.redis.VelocityRedis;
 import com.velocityctd.proxy.redis.depot.AbstractDepotService;
 import com.velocityctd.proxy.redis.impl.packet.VelocityKick;
+import com.velocitypowered.api.proxy.player.PlayerSettings;
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
@@ -174,6 +175,22 @@ public final class PlayerDepotService extends AbstractDepotService<UUID, PlayerE
     }
 
     playerEntry.setServerName(serverName);
+    playerEntry.upsert();
+  }
+
+  /**
+   * Called when a {@link ConnectedPlayer} changes its {@link PlayerSettings}.
+   *
+   * @param player the player that got its settings changed
+   * @param settings the new settings
+   */
+  public void onPlayerSettingsChange(final ConnectedPlayer player, final PlayerSettings settings) {
+    final PlayerEntry playerEntry = this.getPlayerEntry(player.getUniqueId());
+    if (playerEntry == null) {
+      return;
+    }
+
+    playerEntry.setClientListingAllowed(settings.isClientListingAllowed());
     playerEntry.upsert();
   }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/impl/depot/PlayerEntry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/impl/depot/PlayerEntry.java
@@ -21,6 +21,7 @@ import com.velocityctd.proxy.redis.depot.DepotEntry;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
+import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -70,6 +71,13 @@ public final class PlayerEntry extends DepotEntry<UUID, PlayerEntry> {
   private final String ipAddress;
 
   /**
+   * Whether this player entry may be listed in the server list ping MOTD hover, generated in
+   * {@link com.velocitypowered.proxy.connection.util.ServerListPingHandler}.
+   * Reflects {@link ClientSettingsPacket#isClientListingAllowed()}.
+   */
+  private boolean clientListingAllowed;
+
+  /**
    * Constructs a new {@link PlayerEntry} from a {@link ConnectedPlayer}.
    *
    * @param player the player to construct from
@@ -88,6 +96,7 @@ public final class PlayerEntry extends DepotEntry<UUID, PlayerEntry> {
         .map(ServerInfo::getName)
         .orElse(null);
     this.ipAddress = player.getRemoteAddress().getAddress().getHostAddress();
+    this.clientListingAllowed = player.getPlayerSettings().isClientListingAllowed();
   }
 
   /**
@@ -160,5 +169,25 @@ public final class PlayerEntry extends DepotEntry<UUID, PlayerEntry> {
    */
   public @Nullable String getIpAddress() {
     return ipAddress;
+  }
+
+  /**
+   * Whether this player entry may be listed in the server list ping MOTD hover, generated in
+   * {@link com.velocitypowered.proxy.connection.util.ServerListPingHandler}.
+   * Reflects {@link ClientSettingsPacket#isClientListingAllowed()}.
+   *
+   * @return true if the client listing is allowed
+   */
+  public boolean isClientListingAllowed() {
+    return clientListingAllowed;
+  }
+
+  /**
+   * Sets clientListingAllowed. Should reflect {@link ClientSettingsPacket#isClientListingAllowed()}.
+   *
+   * @param clientListingAllowed whether this player may be listed in the server list ping MOTD hover
+   */
+  public void setClientListingAllowed(boolean clientListingAllowed) {
+    this.clientListingAllowed = clientListingAllowed;
   }
 }

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/impl/depot/PlayerEntry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/impl/depot/PlayerEntry.java
@@ -18,6 +18,7 @@
 package com.velocityctd.proxy.redis.impl.depot;
 
 import com.velocityctd.proxy.redis.depot.DepotEntry;
+import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import java.util.HashMap;
@@ -50,38 +51,23 @@ public final class PlayerEntry extends DepotEntry<UUID, PlayerEntry> {
   /**
    * Whether this player is permitted to bypass full server restrictions.
    */
-  private boolean fullServerBypass = false;
+  private final boolean fullServerBypass;
 
   /**
    * Whether this player is permitted to bypass queue placement entirely.
    */
-  private boolean queueBypass = false;
+  private final boolean queueBypass;
 
   /**
    * The name of the backend server the player is currently connected to,
    * or {@code null} if the player is not on any server.
    */
-  private String serverName = null;
+  private String serverName;
 
   /**
    * The IP address of the player, or {@code null} if not available.
    */
-  private String ipAddress = null;
-
-  /**
-   * Constructs a new {@link PlayerEntry}.
-   *
-   * @param uniqueId the player's unique id
-   * @param username the player's username
-   * @param proxyId the ID of the proxy the player is on
-   */
-  public PlayerEntry(final UUID uniqueId, final String username, final String proxyId) {
-    super(uniqueId);
-
-    this.username = username;
-    this.proxyId = proxyId;
-    this.queuePriority = new HashMap<>();
-  }
+  private final String ipAddress;
 
   /**
    * Constructs a new {@link PlayerEntry} from a {@link ConnectedPlayer}.
@@ -89,28 +75,19 @@ public final class PlayerEntry extends DepotEntry<UUID, PlayerEntry> {
    * @param player the player to construct from
    * @param proxyId the ID of the proxy the player is on
    */
-  public PlayerEntry(final @NotNull ConnectedPlayer player, final String proxyId) {
-    this(player.getUniqueId(), player.getUsername(), proxyId);
+  PlayerEntry(final @NotNull ConnectedPlayer player, final String proxyId) {
+    super(player.getUniqueId());
 
-    this.setServer(player.getCurrentServer().orElse(null));
+    this.username = player.getUsername();
+    this.proxyId = proxyId;
+    this.queuePriority = new HashMap<>(player.getQueuePriorities());
     this.fullServerBypass = player.hasPermission("velocity.queue.full.bypass");
     this.queueBypass = player.hasPermission("velocity.queue.bypass");
-    this.queuePriority.putAll(player.getQueuePriorities());
+    this.serverName = player.getCurrentServer()
+        .map(VelocityServerConnection::getServerInfo)
+        .map(ServerInfo::getName)
+        .orElse(null);
     this.ipAddress = player.getRemoteAddress().getAddress().getHostAddress();
-  }
-
-  /**
-   * Sets the server the player is currently on.
-   *
-   * @param connection the server connection the player is on
-   */
-  public void setServer(final @Nullable VelocityServerConnection connection) {
-    if (connection == null) {
-      this.serverName = null;
-      return;
-    }
-
-    this.serverName = connection.getServerInfo().getName();
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -675,6 +675,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     final ClientSettingsWrapper cs = new ClientSettingsWrapper(clientSettingsPacket);
     this.settings = cs;
     server.getEventManager().fireAndForget(new PlayerSettingsChangedEvent(this, cs));
+
+    if (server.isRedisEnabled()) {
+      server.getRedis().getPlayerService().onPlayerSettingsChange(this, cs);
+    }
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -90,7 +90,13 @@ public class ServerListPingHandler {
       List<ServerPing.SamplePlayer> unshuffledPlayers;
       if (server.isRedisEnabled()) {
         unshuffledPlayers = server.getRedis().getPlayerService().getAll().stream()
-            .map(entry -> new ServerPing.SamplePlayer(entry.getUsername(), entry.getUniqueId()))
+            .map(entry -> {
+              if (entry.isClientListingAllowed()) {
+                return new ServerPing.SamplePlayer(entry.getUsername(), entry.getUniqueId());
+              } else {
+                return ServerPing.SamplePlayer.ANONYMOUS;
+              }
+            })
             .collect(Collectors.toList());
       } else {
         unshuffledPlayers = server.getAllPlayers().stream()

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
@@ -61,7 +61,7 @@ public enum TranslatableMapper implements BiConsumer<TranslatableComponent, Cons
       componentConsumer.accept(GlobalTranslator.render(translatableComponent, locale));
     } else {
       String fallback = translatableComponent.fallback();
-      if (fallback == null) {
+      if (fallback == null || fallback.isBlank()) {
         fallback = translatableComponent.key();
       }
 


### PR DESCRIPTION
- Honor `PlayerSettings#isClientListingAllowed` when redis is enabled (Notchian behavior)
- Attempt to fix #728 by falling back to translation key when fallback is blank