### PR TITLE
Merge `dev` into `libdeflate`

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/command/builtin/TransferCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/builtin/TransferCommand.java
@@ -224,7 +224,7 @@ public class TransferCommand implements BuiltinCommand {
                 .arguments(Argument.string("player", playerEntry.getUsername()),
                         Argument.string("proxy", normalizedProxyId)));
 
-        new VelocityTransferRemote(context.getSource(), playerEntry.getUniqueId(), proxyId, address.ip(), address.port())
+        new VelocityTransferRemote(context.getSource(), playerEntry.getUniqueId(), address.ip(), address.port())
                 .publish();
       } else {
         Optional<ConnectedPlayer> maybePlayer = this.server.getPlayer(player);

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/impl/packet/VelocityRemote.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/impl/packet/VelocityRemote.java
@@ -26,11 +26,6 @@ import java.util.UUID;
 public final class VelocityRemote extends UuidPacket {
 
   /**
-   * The identifier of the proxy from which the player is being redirected.
-   */
-  private final String proxyId;
-
-  /**
    * The IP address of the remote server the player should be sent to.
    */
   private final String ip;
@@ -44,25 +39,14 @@ public final class VelocityRemote extends UuidPacket {
    * Constructs a new {@link VelocityRemote} packet.
    *
    * @param uniqueId the player's unique ID
-   * @param proxyId the ID of the proxy the player is on
    * @param ip the IP address of the remote server
    * @param port the port of the remote server
    */
-  public VelocityRemote(final UUID uniqueId, final String proxyId, final String ip, final int port) {
+  public VelocityRemote(final UUID uniqueId, final String ip, final int port) {
     super(uniqueId);
 
-    this.proxyId = proxyId;
     this.ip = ip;
     this.port = port;
-  }
-
-  /**
-   * Gets the ID of the proxy the player is on.
-   *
-   * @return the ID of the proxy the player is on
-   */
-  public String getProxyId() {
-    return proxyId;
   }
 
   /**

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/impl/transaction/VelocityTransferRemote.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/impl/transaction/VelocityTransferRemote.java
@@ -36,12 +36,11 @@ public final class VelocityTransferRemote extends VelocityTransaction<VelocityRe
    *
    * @param source the command source to send the result to
    * @param uniqueId the player's unique ID
-   * @param proxyId the ID of the proxy the player is on
    * @param ip the IP address of the remote server
    * @param port the port of the remote server
    */
-  public VelocityTransferRemote(final @NotNull CommandSource source, final UUID uniqueId, final String proxyId, final String ip, final int port) {
-    super(new VelocityRemote(uniqueId, proxyId, ip, port), source, "redis.command.transfer.timeout");
+  public VelocityTransferRemote(final @NotNull CommandSource source, final UUID uniqueId, final String ip, final int port) {
+    super(new VelocityRemote(uniqueId, ip, port), source, "redis.command.transfer.timeout");
 
     this.onComplete(packet -> PacketBehaviour.SEND_COMPONENT.behave(source, packet));
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/ProxyOptions.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/ProxyOptions.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
@@ -187,7 +188,7 @@ public final class ProxyOptions {
 
       if (split.length == 4) {
         try {
-          mode = ServerInfoForwardingMode.valueOf(split[3].toUpperCase());
+          mode = ServerInfoForwardingMode.valueOf(split[3].toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
           throw new ValueConversionException("Invalid forwarding mode for server flag with name: " + split[0]);
         }

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -528,7 +528,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     }
 
     gameProfileFetcher = new GameProfileFetcher(this);
-    if (configuration.isCachePlayerProfileResultEnabled()) {
+    if (configuration.isCachePlayerProfileResultEnabled() && configuration.isOnlineMode()) {
       LOGGER.debug("Registering memory profile cache");
       gameProfileFetcher.getCacheLayers().addFirst(new MemoryGameProfileCache(
           Duration.ofMinutes(configuration.getProfileCacheExpiryMinutes()),
@@ -539,7 +539,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     if (configuration.getRedis().isEnabled()) {
       redis = new VelocityRedis(this);
 
-      if (configuration.isCachePlayerProfileResultEnabled()) {
+      if (configuration.isCachePlayerProfileResultEnabled() && configuration.isOnlineMode()) {
         LOGGER.debug("Registering Redis profile cache");
         gameProfileFetcher.getCacheLayers().addLast(new RedisGameProfileCache(
             redis.getProvider(),

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -1734,7 +1734,9 @@ public final class VelocityConfiguration implements ProxyConfig {
               }
 
               if (entry2.getKey().equalsIgnoreCase("forwarding-mode")) {
-                forwardingMode = ServerInfoForwardingMode.valueOf(ServerInfoForwardingMode.class, entry2.getValue());
+                String forwardingModeName = entry2.getValue();
+                forwardingMode = ServerInfoForwardingMode.valueOf(
+                    forwardingModeName.toUpperCase(Locale.ROOT));
               }
 
               if (entry2.getKey().equalsIgnoreCase("minimum-version")) {

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -165,8 +165,8 @@ override-server-command-usage = false
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.
 lobby = "127.0.0.1:30066"
-factions  = { address = "127.0.0.1:30067", forwarding-mode = "MODERN", minimum-version = "1.13" }
-minigames = { address = "127.0.0.1:30068", forwarding-mode = "LEGACY", minimum-version = "1.7.2", maximum-version = "1.21.10" }
+factions  = { address = "127.0.0.1:30067", forwarding-mode = "modern", minimum-version = "1.13" }
+minigames = { address = "127.0.0.1:30068", forwarding-mode = "legacy", minimum-version = "1.7.2", maximum-version = "1.21.10" }
 
 # In what order, we should try servers when a player logs in or is kicked from a server.
 try = [


### PR DESCRIPTION
- `forwarding-mode` in `[servers]` may now be lowercase (aligns with rest of config)
- Cleaned up `VelocityRemote` and `VelocityTransferRemote` with unused field
- Only allow profile caching in online mode. There's an exploit where offline mode players can impersonate online mode players when they have joined previously through the caching. A possible fix exists in [n4aaa/Velocity-CTD](https://github.com/n4aaa/Velocity-CTD), see https://github.com/n4aaa/Velocity-CTD/commit/b1500e6a17b9028299ac97a57b66e68978310222