### PR TITLE
`org.lanternpowered:lmbda` 3.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ kyori-ansi = "net.kyori:ansi:1.1.1"
 guava = "com.google.guava:guava:33.5.0-jre"
 gson = "com.google.code.gson:gson:2.13.2"
 guice = "com.google.inject:guice:7.0.0"
-lmbda = "org.lanternpowered:lmbda:2.0.0"
+lmbda = "org.lanternpowered:lmbda:3.0.0"
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 log4j-slf4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/CustomHandlerAdapter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/CustomHandlerAdapter.java
@@ -82,9 +82,7 @@ final class CustomHandlerAdapter<F> {
 
   UntargetedEventHandler buildUntargetedHandler(final Method method) throws IllegalAccessException {
     final MethodHandle methodHandle = methodHandlesLookup.unreflect(method);
-    final MethodHandles.Lookup defineLookup = MethodHandles.privateLookupIn(
-        method.getDeclaringClass(), methodHandlesLookup);
-    final LambdaType<F> lambdaType = functionType.defineClassesWith(defineLookup);
+    final LambdaType<F> lambdaType = functionType.defineClassesWith(methodHandlesLookup);
     final F invokeFunction = LambdaFactory.create(lambdaType, methodHandle);
     final BiFunction<Object, Object, EventTask> handlerFunction =
         handlerBuilder.apply(invokeFunction);

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
@@ -327,7 +327,7 @@ public class VelocityEventManager implements EventManager {
       type = UNTARGETED_VOID_HANDLER_TYPE;
     }
 
-    return LambdaFactory.create(type.defineClassesWith(lookup), methodHandle);
+    return LambdaFactory.create(type.defineClassesWith(METHOD_HANDLES_LOOKUP), methodHandle);
   }
 
   static final class MethodHandlerInfo {


### PR DESCRIPTION
`org.lanternpowered:lmbda` 3.0.0 switched from `Unsafe.defineAnonymousClass` to `MethodHandles.Lookup.defineHiddenClass`, which requires MODULE access. `privateLookupIn()` dropped that access when targeting a different module (e.g. plugin classes), causing IllegalAccessException. This PR uses the proxy's own lookup for class definition while keeping the teleported lookup for method unreflection.