### PR TITLE
fix: handle non-text kick components in shutdown requeue

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -110,6 +110,7 @@ import com.velocitypowered.proxy.tablist.KeyedVelocityTabList;
 import com.velocitypowered.proxy.tablist.VelocityTabList;
 import com.velocitypowered.proxy.tablist.VelocityTabListLegacy;
 import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
+import com.velocitypowered.proxy.util.ComponentUtils;
 import com.velocitypowered.proxy.util.DurationUtils;
 import com.velocitypowered.proxy.util.TranslatableMapper;
 import com.velocitypowered.proxy.util.collect.CappedSet;
@@ -1328,7 +1329,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
     if (this.server.isQueueEnabled() && disconnectReason instanceof TextComponent text) {
       for (String reason : this.server.getConfiguration().getQueue().getBannedReason()) {
-        if (containsString(text, reason)) {
+        if (ComponentUtils.containsString(text, reason)) {
           this.server.getQueueManager().removePlayerEntirely(this);
           break;
         }
@@ -1448,7 +1449,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
                       // This is done to make sure players don't get constantly sent over and over again in a kick loop
                       boolean isValidReason = this.server.getConfiguration().getQueue().getBannedReason()
                           .stream()
-                          .noneMatch(text -> containsString(kickMsg, text));
+                          .noneMatch(text -> ComponentUtils.containsString(kickMsg, text));
 
                       if (isValidReason && (queue.getState() != QueueState.PAUSED
                           || this.server.getConfiguration().getQueue().isAllowPausedQueueJoining())) {
@@ -2476,9 +2477,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
                     .orElse(ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR);
             handleConnectionException(toConnect, DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()), status.isSafe());
 
-            if (server.isQueueEnabled() && reason instanceof TextComponent textComponent) {
+            if (server.isQueueEnabled()) {
               for (String r : server.getConfiguration().getQueue().getBannedReason()) {
-                if (containsString(textComponent, r)) {
+                if (ComponentUtils.containsString(reason, r)) {
                   server.getQueueManager().removePlayerEntirely(ConnectedPlayer.this);
                 }
               }
@@ -2607,21 +2608,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     private boolean hasSameName(final VelocityRegisteredServer server, final String name) {
       return server.getServerInfo().getName().equalsIgnoreCase(name);
     }
-  }
-
-  private static boolean containsString(final Component component, final String searchString) {
-    if (component instanceof TextComponent textComponent
-        && textComponent.content().contains(searchString)) {
-      return true;
-    }
-
-    for (Component child : component.children()) {
-      if (containsString(child, searchString)) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1441,7 +1441,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
                     String targetServerName = originalEvent.getServer().getServerInfo().getName();
 
                     if (!this.server.getConfiguration().getQueue().getNoQueueServers().contains(targetServerName)) {
-                      TextComponent kickMsg = (TextComponent) originalEvent.getServerKickReason().orElse(Component.empty());
+                      Component kickMsg = originalEvent.getServerKickReason().orElse(Component.empty());
                       final VelocityQueue queue = this.server.getQueueManager().getQueue(targetServerName);
 
                       // Checks if the kick reason is valid for a re-queue
@@ -2609,17 +2609,15 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     }
   }
 
-  private static boolean containsString(final TextComponent component, final String searchString) {
-    if (component.content().contains(searchString)) {
+  private static boolean containsString(final Component component, final String searchString) {
+    if (component instanceof TextComponent textComponent
+        && textComponent.content().contains(searchString)) {
       return true;
     }
 
-    // Recursively check children components
     for (Component child : component.children()) {
-      if (child instanceof TextComponent textChild) {
-        if (containsString(textChild, searchString)) {
-          return true;
-        }
+      if (containsString(child, searchString)) {
+        return true;
       }
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -150,7 +150,6 @@ import net.kyori.adventure.resource.ResourcePackRequestLike;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
@@ -1327,9 +1326,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
                   Argument.component("reason", disconnectReason)), safe);
     }
 
-    if (this.server.isQueueEnabled() && disconnectReason instanceof TextComponent text) {
+    if (this.server.isQueueEnabled()) {
       for (String reason : this.server.getConfiguration().getQueue().getBannedReason()) {
-        if (ComponentUtils.containsString(text, reason)) {
+        if (ComponentUtils.containsString(disconnectReason, reason)) {
           this.server.getQueueManager().removePlayerEntirely(this);
           break;
         }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ComponentUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ComponentUtils.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.jetbrains.annotations.NotNull;
 
@@ -202,6 +203,29 @@ public final class ComponentUtils {
     }
 
     return input;
+  }
+
+  /**
+   * Returns whether the component tree contains the provided string in any text node.
+   *
+   * @param component the component to inspect
+   * @param searchString the text to find
+   * @return {@code true} if found, {@code false} otherwise
+   */
+  public static boolean containsString(final @NotNull Component component,
+                                       final @NotNull String searchString) {
+    if (component instanceof TextComponent textComponent
+        && textComponent.content().contains(searchString)) {
+      return true;
+    }
+
+    for (Component child : component.children()) {
+      if (containsString(child, searchString)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private static @NotNull String colorMatcher(@NotNull String literal, final @NotNull Pattern pattern, final boolean unboxed) {


### PR DESCRIPTION
Fixes queue re-add on backend shutdown fallback by handling kick reasons as generic `Component` instead of only `TextComponent`.
