### PR TITLE
Windows Terminal Fix

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ fastutil = "it.unimi.dsi:fastutil:8.5.18"
 flare-core = { module = "space.vectrix.flare:flare", version.ref = "flare" }
 flare-fastutil = { module = "space.vectrix.flare:flare-fastutil", version.ref = "flare" }
 jline = "org.jline:jline-terminal-jansi:3.30.9"
+jline-jni = "org.jline:jline-terminal-jni:3.30.9"
 lettuce-core = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
 jopt = "net.sf.jopt-simple:jopt-simple:5.0.4"
 junit = "org.junit.jupiter:junit-jupiter:6.0.3"

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -173,6 +173,7 @@ dependencies {
     implementation(libs.jopt)
     implementation(libs.terminalconsoleappender)
     runtimeOnly(libs.jline)
+    runtimeOnly(libs.jline.jni)
     runtimeOnly(libs.disruptor)
     implementation(libs.fastutil)
     implementation(platform(libs.adventure.bom))


### PR DESCRIPTION
Tab completion on Windows was no longer working due to a change that came with jline. As a solution, jline-jni was added.

New Terminal
<img width="1093" height="219" alt="resim" src="https://github.com/user-attachments/assets/55ff3900-a77c-4c96-bca0-8033c4961771" />

Old Terminal:
<img width="1088" height="234" alt="resim" src="https://github.com/user-attachments/assets/77f0631f-d360-4041-a884-5e01cd63d2b9" />

