### PR TITLE
Queue server feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ dependencies, useful performance improvements, and more.
 * `velocity.queue.full.bypass` (Allows you to connect to a server even when it is at capacity).
 * `velocity.queue.leave` (Allows you to leave the queue you are in or all queues you are in).
 * `velocity.queue.priority.{ALL/SERVER}.{WEIGHT}` (Sets the position you are in for the/a queue).
+* `velocity.queue.server-switch.bypass` (Allows you to switch servers freely while in a queue,
+  even when `queue-server` is configured. Without this permission, players on the `queue-server`
+  are blocked from switching to any server other than their queued destination).
 * `velocity.queue.timeout.{SECONDS}` (Specifies the amount of time a user has before they
   are unqueued from a server when disconnecting; if you reach the position where
   you can be sent and are offline, your queue position will reset, regardless of

--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -304,6 +304,12 @@ public class CtdConfigMigrations {
             ""
         ),
         migration(
+            "The server queue(s) a player is automatically entered into on their first proxy join.\n"
+                + " Can be configured as a single string or a list of strings.",
+            "queue.queue-on-join",
+            List.of()
+        ),
+        migration(
             "Whether the kick message or indicator should be shown when you have failed to queue and join a specific server.",
             "queue.forward-kick-reason",
             true

--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -295,6 +295,15 @@ public class CtdConfigMigrations {
             true
         ),
         migration(
+            "The server that players will be moved to when they enter ANY queue.\n"
+                + " When a player queues for any server, they will be automatically sent to this server.\n"
+                + " While in a queue and on this server, any server switch attempts will be blocked unless\n"
+                + " the player has the velocity.queue.server-switch.bypass permission.\n"
+                + " This is mutually exclusive with auto-queue-servers. Leave empty to disable.",
+            "queue.queue-server",
+            ""
+        ),
+        migration(
             "Whether the kick message or indicator should be shown when you have failed to queue and join a specific server.",
             "queue.forward-kick-reason",
             true

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
@@ -256,6 +256,18 @@ public class VelocityQueueManager implements QueueManager {
     queue.enqueue(player);
     player.sendMessage(Component.translatable("velocity.queue.command.queued")
         .arguments(Component.text(targetName)));
+
+    // If a queue-server is configured, move the player there if they aren't already on it
+    final String queueServerName = config.getQueueServer();
+    if (!queueServerName.isEmpty()) {
+      server.getServer(queueServerName).ifPresentOrElse(queueServer -> {
+        player.getCurrentServer().ifPresent(currentServer -> {
+          if (!currentServer.getServerInfo().getName().equals(queueServerName)) {
+            player.createConnectionRequest(queueServer).connectWithIndication();
+          }
+        });
+      }, () -> LOGGER.warn("Queue server '{}' is configured but not registered!", queueServerName));
+    }
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2954,6 +2954,12 @@ public final class VelocityConfiguration implements ProxyConfig {
      */
     private Map<String, List<String>> autoQueueServers;
 
+    /**
+     * The name of the server players are moved to when they enter any queue.
+     * Mutually exclusive with auto-queue-servers.
+     */
+    private String queueServer;
+
     private Queue(final CommentedConfig config) {
       if (config == null) {
         return;
@@ -2976,10 +2982,19 @@ public final class VelocityConfiguration implements ProxyConfig {
       this.queueAdminAliases = config.getOrElse("queue-admin-aliases", new ArrayList<>());
       this.masterProxyIds = config.getOrElse("master-proxy-ids", new ArrayList<>());
       this.bannedReason = config.getOrElse("banned-reason", new ArrayList<>());
+      this.queueServer = config.getOrElse("queue-server", "");
       this.autoQueueServers = parseAutoQueueServers(config.get("auto-queue-servers"));
+
+      if (!this.queueServer.isEmpty() && !this.autoQueueServers.isEmpty()) {
+        LOGGER.warn("Both 'queue-server' and 'auto-queue-servers' are configured in [queue]. "
+            + "These features are mutually exclusive; 'auto-queue-servers' will be ignored.");
+      }
     }
 
     private Map<String, List<String>> parseAutoQueueServers(CommentedConfig config) {
+      if (config == null) {
+        return ImmutableMap.of();
+      }
       Map<String, List<String>> autoQueueServers = new HashMap<>();
       for (UnmodifiableConfig.Entry entry : config.entrySet()) {
         String key = entry.getKey();
@@ -3161,6 +3176,16 @@ public final class VelocityConfiguration implements ProxyConfig {
       return autoQueueServers;
     }
 
+    /**
+     * Gets the name of the server players are moved to when they enter any queue.
+     * Empty string means disabled.
+     *
+     * @return the queue server name, or an empty string if not configured
+     */
+    public String getQueueServer() {
+      return queueServer == null ? "" : queueServer;
+    }
+
     @Override
     public String toString() {
       return "Queue{"
@@ -3178,6 +3203,7 @@ public final class VelocityConfiguration implements ProxyConfig {
           + ", overrideBungeeMessaging=" + overrideBungeeMessaging
           + ", leaveQueueAliases=" + leaveQueueAliases
           + ", autoQueueServers=" + autoQueueServers
+          + ", queueServer=" + queueServer
           + ", queueAdminAliases=" + queueAdminAliases
           + ", masterProxyIds=" + masterProxyIds
           + ", bannedReason=" + bannedReason

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2960,6 +2960,11 @@ public final class VelocityConfiguration implements ProxyConfig {
      */
     private String queueServer;
 
+    /**
+     * A list of server queues a player is automatically entered into on their first proxy join.
+     */
+    private List<String> queueOnJoinServers;
+
     private Queue(final CommentedConfig config) {
       if (config == null) {
         return;
@@ -2983,6 +2988,7 @@ public final class VelocityConfiguration implements ProxyConfig {
       this.masterProxyIds = config.getOrElse("master-proxy-ids", new ArrayList<>());
       this.bannedReason = config.getOrElse("banned-reason", new ArrayList<>());
       this.queueServer = config.getOrElse("queue-server", "");
+      this.queueOnJoinServers = parseQueueOnJoinServers(config.get("queue-on-join"));
       this.autoQueueServers = parseAutoQueueServers(config.get("auto-queue-servers"));
 
       if (!this.queueServer.isEmpty() && !this.autoQueueServers.isEmpty()) {
@@ -3011,6 +3017,19 @@ public final class VelocityConfiguration implements ProxyConfig {
       }
 
       return ImmutableMap.copyOf(autoQueueServers);
+    }
+
+    private List<String> parseQueueOnJoinServers(Object raw) {
+      if (raw instanceof String s) {
+        return s.isEmpty() ? ImmutableList.of() : ImmutableList.of(s);
+      } else if (raw instanceof List<?> list) {
+        return list.stream()
+            .filter(e -> e instanceof String)
+            .map(e -> (String) e)
+            .filter(s -> !s.isEmpty())
+            .collect(ImmutableList.toImmutableList());
+      }
+      return ImmutableList.of();
     }
 
     /**
@@ -3186,6 +3205,15 @@ public final class VelocityConfiguration implements ProxyConfig {
       return queueServer == null ? "" : queueServer;
     }
 
+    /**
+     * Gets the list of server queues a player is automatically entered into on their first proxy join.
+     *
+     * @return list of server names, or an empty list if not configured
+     */
+    public List<String> getQueueOnJoinServers() {
+      return queueOnJoinServers == null ? ImmutableList.of() : queueOnJoinServers;
+    }
+
     @Override
     public String toString() {
       return "Queue{"
@@ -3204,6 +3232,7 @@ public final class VelocityConfiguration implements ProxyConfig {
           + ", leaveQueueAliases=" + leaveQueueAliases
           + ", autoQueueServers=" + autoQueueServers
           + ", queueServer=" + queueServer
+          + ", queueOnJoinServers=" + queueOnJoinServers
           + ", queueAdminAliases=" + queueAdminAliases
           + ", masterProxyIds=" + masterProxyIds
           + ", bannedReason=" + bannedReason

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -388,10 +388,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   private @Nullable ServerRetrySession serverRetrySession;
 
   /**
-   * The task that delays the auto-queue operation. This is kept track of to cancel this
-   * task on disconnect.
+   * Tasks that delay the queueing operations. These are kept track of to cancel these
+   * tasks on disconnect.
    */
   private @Nullable ScheduledTask tryAutoQueueTask;
+  private @Nullable ScheduledTask tryQueueOnJoinTask;
 
   ConnectedPlayer(final VelocityServer server, final GameProfile profile, final MinecraftConnection connection,
                   final @Nullable InetSocketAddress virtualHost, final @Nullable String rawVirtualHost, final boolean onlineMode,
@@ -433,6 +434,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     if (tryAutoQueueTask != null) {
       tryAutoQueueTask.cancel();
       tryAutoQueueTask = null;
+    }
+
+    if (tryQueueOnJoinTask != null) {
+      tryQueueOnJoinTask.cancel();
+      tryQueueOnJoinTask = null;
     }
 
     if (this.fullyConnected) {
@@ -1539,6 +1545,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
         if (queueServerName.isEmpty()) {
           tryAutoQueue(serverConnection);
         }
+
+        if (!firstServerConnected) {
+          tryQueueOnJoin(serverConnection);
+        }
       }
 
       if (!firstServerConnected) {
@@ -1641,6 +1651,42 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
         VelocityRegisteredServer target = queueServers.getFirst();
         server.getQueueManager().queue(this, target);
       }
+    })
+        .delay(Duration.ofSeconds(2))
+        .schedule();
+  }
+
+  private void tryQueueOnJoin(final @NonNull VelocityServerConnection firstServer) {
+    final List<String> queueOnJoinServers = server.getConfiguration().getQueue().getQueueOnJoinServers();
+    if (queueOnJoinServers.isEmpty()) {
+      return;
+    }
+
+    LOGGER.debug("Scheduling queue-on-join for player {}.", getUsername());
+
+    tryQueueOnJoinTask = server.getScheduler().buildTask(VelocityVirtualPlugin.INSTANCE, () -> {
+      // Safeguard if this player is offline. Should never be reached because the task
+      // should be cancelled by ConnectedPlayer#disconnected.
+      if (!server.getAllPlayers().contains(this)) {
+        LOGGER.debug("Aborting queue-on-join for player {} (now offline).", getUsername());
+        return;
+      }
+
+      if (connectedServer != firstServer || connectionInFlight != null) {
+        LOGGER.debug("Aborting queue-on-join for player {} (server mismatch).", getUsername());
+        return;
+      }
+
+      LOGGER.debug("Applying queue-on-join for player {}.", getUsername());
+
+      for (final String targetName : queueOnJoinServers) {
+        server.getServer(targetName).ifPresentOrElse(
+            target -> server.getQueueManager().queue(this, target),
+            () -> LOGGER.warn("queue-on-join server '{}' is not registered!", targetName)
+        );
+      }
+
+      tryQueueOnJoinTask = null;
     })
         .delay(Duration.ofSeconds(2))
         .schedule();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1522,19 +1522,69 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
     if (serverConnection != null) {
       if (server.isQueueEnabled()) {
-        if (server.getConfiguration().getQueue().isRemovePlayerOnServerSwitch() && firstServerConnected) {
+        final String queueServerName = server.getConfiguration().getQueue().getQueueServer();
+        final boolean destinationIsQueueServer = !queueServerName.isEmpty()
+            && serverConnection.getServerInfo().getName().equals(queueServerName);
+
+        if (!destinationIsQueueServer
+            && server.getConfiguration().getQueue().isRemovePlayerOnServerSwitch()
+            && firstServerConnected) {
           // Only remove player from all queues entirely if this is NOT the first server we connect to (firstServerConnected flag)
-          // to ensure timeouts work correctly when a player re-joins the network/
+          // to ensure timeouts work correctly when a player re-joins the network.
+          // Also skip removal when moving to the queue-server so the player stays in their queue.
           server.getQueueManager().removePlayerEntirely(this);
         }
 
-        tryAutoQueue(serverConnection);
+        // Auto-queue is mutually exclusive with queue-server
+        if (queueServerName.isEmpty()) {
+          tryAutoQueue(serverConnection);
+        }
       }
 
       if (!firstServerConnected) {
         firstServerConnected = true;
       }
     }
+  }
+
+  /**
+   * Returns {@code true} if the given server switch should be blocked because the player is
+   * in a queue while on the configured queue-server, and does not have the bypass permission.
+   *
+   * <p>The switch is allowed (returns {@code false}) if the destination is one of the servers
+   * the player is currently queued for — this ensures the queue manager can still transfer the
+   * player to their destination without being blocked.</p>
+   */
+  private boolean shouldBlockQueueServerSwitch(final VelocityRegisteredServer destination) {
+    if (!server.isQueueEnabled()) {
+      return false;
+    }
+
+    final String queueServerName = server.getConfiguration().getQueue().getQueueServer();
+    if (queueServerName.isEmpty()) {
+      return false;
+    }
+
+    // Only block if the player is currently on the queue-server
+    if (connectedServer == null || !connectedServer.getServerInfo().getName().equals(queueServerName)) {
+      return false;
+    }
+
+    // Don't block if the player is not in any queue
+    if (!server.getQueueManager().isQueued(this)) {
+      return false;
+    }
+
+    // Allow the switch if the destination is a server the player is queued for
+    // (i.e. the queue manager is sending them to their destination)
+    for (final var queue : server.getQueueManager().getQueues()) {
+      if (queue.contains(this) && queue.getName().equals(destination.getServerInfo().getName())) {
+        return false;
+      }
+    }
+
+    // Allow if the player has the bypass permission
+    return !hasPermission("velocity.queue.server-switch.bypass");
   }
 
   private void tryAutoQueue(final @NonNull VelocityServerConnection joinedServer) {
@@ -2408,6 +2458,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       return this.getInitialStatus().thenCompose(initialCheck -> {
         if (initialCheck.isPresent()) {
           return completedFuture(plainResult(initialCheck.get(), toConnect));
+        }
+
+        if (shouldBlockQueueServerSwitch(toConnect)) {
+          sendMessage(Component.translatable("velocity.queue.error.server-switch-blocked"));
+          return completedFuture(plainResult(ConnectionRequestBuilder.Status.CONNECTION_CANCELLED, toConnect));
         }
 
         ServerPreConnectEvent event = new ServerPreConnectEvent(ConnectedPlayer.this, toConnect, previousServer);

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -203,6 +203,7 @@ velocity.queue.error.already-connected=<red><arg:0> is already connected to this
 velocity.queue.error.max-send-retries-reached=<red>Unable to connect you to <arg:0>. You reached the maximum of <arg:1> retries.
 velocity.queue.error.server-has-no-queue=<red><arg:0> has its queue disabled.
 velocity.queue.error.same-server-queue=<red>You cannot queue the same servers to each other.
+velocity.queue.error.server-switch-blocked=<red>You cannot switch servers while in a queue.
 # Queue server estimated time formats
 velocity.queue.time.second=<arg:0>s
 velocity.queue.time.seconds=<arg:0>s

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -491,6 +491,13 @@ remove-player-on-server-switch = true
 # This is mutually exclusive with auto-queue-servers. Leave empty to disable.
 queue-server = ""
 
+# The server queue(s) a player is automatically entered into on their first proxy join.
+# Can be configured as a single string or a list of strings.
+# Examples:
+#   queue-on-join = "factions"
+#   queue-on-join = ["factions1", "factions2"]
+queue-on-join = []
+
 # Whether the kick message or indicator should be shown when you have failed to queue and join a specific server.
 forward-kick-reason = true
 

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -484,6 +484,13 @@ max-send-retries = 10
 # Whether the player should be removed from their previous queue when switching servers.
 remove-player-on-server-switch = true
 
+# The server that players will be moved to when they enter ANY queue.
+# When a player queues for any server, they will be automatically sent to this server.
+# While in a queue and on this server, any server switch attempts will be blocked unless
+# the player has the velocity.queue.server-switch.bypass permission.
+# This is mutually exclusive with auto-queue-servers. Leave empty to disable.
+queue-server = ""
+
 # Whether the kick message or indicator should be shown when you have failed to queue and join a specific server.
 forward-kick-reason = true
 


### PR DESCRIPTION
Introduces two new config options:
- `queue-server` allows you to configure a specific server all players move to once they enter a queue. This feature is mutually exclusive to `auto-queue-servers`, meaning if `queue-server` is configured `auto-queue-servers` is ignored. This new feature is useful if you want to configure a single "limbo server" a player gets moved to when enqueueing for any other server (the existing `auto-queue-servers` feature requires you to have one limbo server per actual server).
- Introduce `queue-on-join` which works with both the new `queue-server` and existing `auto-queue-servers`, which enqueues a player for one or more servers on first proxy join.

The `queue-server` feature requires us to have another config option `queue-on-join`, which makes a player join a specific queue on first proxy-join. This is necessary to keep functionality which was possible with `auto-queue-servers` natively:

```toml
[servers]
try = "factions-limbo"

[queue.auto-queue-servers]
factions-limbo = "factions"
```

This configuration would make a player join the `factions-limbo` server on join, and the player would immediately get queued for the `factions` server. To join `factions` again, the player would need to join `factions-limbo` and they would get queued for factions.

This can now be configured with:

```toml
[servers]
try = "factions-limbo"  # or a generic 'limbo' server

queue-server = "factions-limbo"
queue-on-join = "factions"
```

To join `factions` again, the player will just need to enqueue for `factions`, making them connect to `factions-limbo` instantly first and connect to `factions` once they're transferred by the queue. This is way more intuitive than before.