### PR TITLE
Merge `dev` into `libdeflate`

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -140,20 +140,6 @@ public interface ProxyConfig {
   boolean isForcedHostAsFallback();
 
   /**
-   * Whether the proxy should cache Mojang profile results to reduce login API pressure.
-   *
-   * @return true if profile result caching is enabled
-   */
-  boolean isCachePlayerProfileResultEnabled();
-
-  /**
-   * How long (in minutes) to cache Mojang profile results.
-   *
-   * @return the profile cache expiration time in minutes
-   */
-  int getProfileCacheExpiryMinutes();
-
-  /**
    * Get the minimum compression threshold for packets.
    *
    * @return the compression threshold

--- a/proxy/src/main/java/com/velocityctd/proxy/cluster/redis/RedisClusterPlayer.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/cluster/redis/RedisClusterPlayer.java
@@ -92,7 +92,7 @@ public final class RedisClusterPlayer implements VelocityClusterPlayer {
 
   @Override
   public void move(final String targetServer) {
-    redis.publish(new VelocitySwitchServer(redisEntry.getUsername(), targetServer));
+    redis.publish(new VelocitySwitchServer(redisEntry.getUniqueId(), targetServer));
   }
 
   @Override
@@ -107,7 +107,7 @@ public final class RedisClusterPlayer implements VelocityClusterPlayer {
 
   @Override
   public CompletableFuture<Long> queryPing() {
-    return redis.publishTransaction(new VelocityGetPlayerPing(redisEntry.getUsername()));
+    return redis.publishTransaction(new VelocityGetPlayerPing(redisEntry.getUniqueId()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocityctd/proxy/command/builtin/TransferCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/builtin/TransferCommand.java
@@ -63,23 +63,26 @@ public class TransferCommand implements BuiltinCommand {
 
   @Override
   public BrigadierCommand build() {
-    if (!this.server.getConfiguration().isAcceptTransfers()) {
-      return null;
+    var subcommand = BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
+        .suggests(PlayerIdentifier.suggest(server, "player"))
+        .executes(ctx -> CommandUtils.emitUsage(ctx, label()));
+
+    if (server.getClusterProxyService().isMultiProxy()) {
+      subcommand = subcommand
+          .then(BrigadierCommand.requiredArgumentBuilder("proxy-id", StringArgumentType.word())
+              .suggests(CommandUtils.suggestProxy(server, "proxy-id"))
+              .executes(this::transferProxyId));
     }
+
+    subcommand = subcommand
+        .then(BrigadierCommand.requiredArgumentBuilder("hostname", StringArgumentType.word())
+            .then(BrigadierCommand.requiredArgumentBuilder("port", IntegerArgumentType.integer(0, 65535))
+                .executes(this::transferHostnameAndPort)));
 
     LiteralCommandNode<CommandSource> transfer = BrigadierCommand.literalArgumentBuilder(label())
         .requires(source -> source.getPermissionValue("velocity.command.transfer") == Tristate.TRUE)
         .executes(ctx -> CommandUtils.emitUsage(ctx, label()))
-        .then(BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
-            .suggests(PlayerIdentifier.suggest(server, "player"))
-            .executes(ctx -> CommandUtils.emitUsage(ctx, label()))
-            .then(BrigadierCommand.requiredArgumentBuilder("hostname", StringArgumentType.word())
-                .then(BrigadierCommand.requiredArgumentBuilder("port", IntegerArgumentType.integer(0, 65535))
-                    .executes(this::transferHostnameAndPort)))
-            .then(BrigadierCommand.requiredArgumentBuilder("proxy-id", StringArgumentType.word())
-                .suggests(CommandUtils.suggestProxy(server, "proxy-id"))
-                .executes(this::transferProxyId))
-        )
+        .then(subcommand)
         .build();
 
     return new BrigadierCommand(transfer);

--- a/proxy/src/main/java/com/velocityctd/proxy/command/builtin/TransferCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/builtin/TransferCommand.java
@@ -18,6 +18,7 @@
 package com.velocityctd.proxy.command.builtin;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.tree.LiteralCommandNode;
@@ -32,9 +33,12 @@ import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.builtin.BuiltinCommand;
 import com.velocitypowered.proxy.command.builtin.CommandMessages;
 import com.velocitypowered.proxy.config.ProxyAddress;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.translation.Argument;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,38 +68,64 @@ public class TransferCommand implements BuiltinCommand {
     }
 
     LiteralCommandNode<CommandSource> transfer = BrigadierCommand.literalArgumentBuilder(label())
-            .requires(source -> source.getPermissionValue("velocity.command.transfer") == Tristate.TRUE)
+        .requires(source -> source.getPermissionValue("velocity.command.transfer") == Tristate.TRUE)
+        .executes(ctx -> CommandUtils.emitUsage(ctx, label()))
+        .then(BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
+            .suggests(PlayerIdentifier.suggest(server, "player"))
             .executes(ctx -> CommandUtils.emitUsage(ctx, label()))
-            .then(BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
-                    .suggests(PlayerIdentifier.suggest(server, "player"))
-                    .executes(ctx -> CommandUtils.emitUsage(ctx, label()))
-                    .then(BrigadierCommand.requiredArgumentBuilder("proxy-id", StringArgumentType.word())
-                            .suggests(CommandUtils.suggestProxy(server, "proxy-id"))
-                            .executes(this::transfer)))
-            .build();
+            .then(BrigadierCommand.requiredArgumentBuilder("hostname", StringArgumentType.word())
+                .then(BrigadierCommand.requiredArgumentBuilder("port", IntegerArgumentType.integer(0, 65535))
+                    .executes(this::transferHostnameAndPort)))
+            .then(BrigadierCommand.requiredArgumentBuilder("proxy-id", StringArgumentType.word())
+                .suggests(CommandUtils.suggestProxy(server, "proxy-id"))
+                .executes(this::transferProxyId))
+        )
+        .build();
 
     return new BrigadierCommand(transfer);
   }
 
-  private int transfer(CommandContext<CommandSource> context) {
+  private int transferHostnameAndPort(CommandContext<CommandSource> context) {
+    String player = context.getArgument("player", String.class);
+    String hostname = context.getArgument("hostname", String.class);
+    int port = context.getArgument("port", Integer.class);
+
+    Address address = new Address(hostname, port);
+    String displayName = address.toString();
+
+    Optional<ProxyAddress> proxyAddress = server.getConfiguration().getProxyAddresses().stream()
+        .filter(address::proxyAddressEquals)
+        .findAny();
+    if (proxyAddress.isPresent()) {
+      displayName += " (" + proxyAddress.get().proxyId() + ")";
+    }
+
+    return transfer(context.getSource(), player, address, displayName);
+  }
+
+  private int transferProxyId(CommandContext<CommandSource> context) {
     String player = context.getArgument("player", String.class);
     String proxyId = context.getArgument("proxy-id", String.class);
     String normalizedProxyId = normalizeProxyId(proxyId);
 
-    ProxyAddress address = server.getConfiguration().getProxyAddresses().stream()
-            .filter(proxy -> proxy.proxyId().equalsIgnoreCase(proxyId))
-            .findFirst()
-            .orElse(null);
+    Optional<Address> address = server.getConfiguration().getProxyAddresses().stream()
+        .filter(proxy -> proxy.proxyId().equalsIgnoreCase(proxyId))
+        .findAny()
+        .map(Address::fromProxyAddress);
 
-    if (address == null) {
+    if (address.isEmpty()) {
       context.getSource().sendMessage(Component.translatable("velocity.command.error.transfer.invalid-proxy")
               .arguments(Component.text(proxyId)));
       return -1;
     }
 
-    PlayerIdentifier.Result result = PlayerIdentifier.resolve(server, player, context.getSource());
+    return transfer(context.getSource(), player, address.get(), normalizedProxyId);
+  }
+
+  private int transfer(CommandSource source, String player, Address address, String targetDisplayName) {
+    PlayerIdentifier.Result result = PlayerIdentifier.resolve(server, player, source);
     if (!result.success()) {
-      sendResolveError(context.getSource(), result);
+      sendResolveError(source, result);
       return -1;
     }
 
@@ -103,13 +133,13 @@ public class TransferCommand implements BuiltinCommand {
       case PLAYER -> {
         if (result.players().size() == 1) {
           VelocityClusterPlayer clusterPlayer = result.players().iterator().next();
-          clusterPlayer.transfer(address.ip(), address.port()).thenAccept(success -> {
+          clusterPlayer.transfer(address.hostname(), address.port()).thenAccept(success -> {
             if (success) {
-              context.getSource().sendMessage(Component.translatable("velocity.command.transfer.success.player")
+              source.sendMessage(Component.translatable("velocity.command.transfer.success.player")
                   .arguments(Argument.string("player", clusterPlayer.getUsername()),
-                      Argument.string("proxy", normalizedProxyId)));
+                      Argument.string("proxy", targetDisplayName)));
             } else {
-              context.getSource().sendMessage(Component.translatable("velocity.command.transfer.invalid-version")
+              source.sendMessage(Component.translatable("velocity.command.transfer.invalid-version")
                   .arguments(Argument.string("player", clusterPlayer.getUsername())));
             }
           }).exceptionally(ex -> {
@@ -118,21 +148,21 @@ public class TransferCommand implements BuiltinCommand {
           });
         } else {
           // Multiple comma-separated players
-          context.getSource().sendMessage(Component.translatable("velocity.command.transfer.success.all")
-                  .arguments(Component.text(normalizedProxyId)));
+          source.sendMessage(Component.translatable("velocity.command.transfer.success.all")
+              .arguments(Component.text(targetDisplayName)));
           transferAll(result, address);
         }
       }
       case SERVER, CURRENT_SERVER -> {
-        context.getSource().sendMessage(Component.translatable("velocity.command.transfer.success.server")
-                .arguments(
-                    Argument.string("server", result.name()),
-                    Argument.string("proxy", normalizedProxyId)));
+        source.sendMessage(Component.translatable("velocity.command.transfer.success.server")
+            .arguments(
+                Argument.string("server", result.name()),
+                Argument.string("proxy", targetDisplayName)));
         transferAll(result, address);
       }
       default -> {
-        context.getSource().sendMessage(Component.translatable("velocity.command.transfer.success.all")
-                .arguments(Component.text(normalizedProxyId)));
+        source.sendMessage(Component.translatable("velocity.command.transfer.success.all")
+            .arguments(Component.text(targetDisplayName)));
         transferAll(result, address);
       }
     }
@@ -140,9 +170,9 @@ public class TransferCommand implements BuiltinCommand {
     return Command.SINGLE_SUCCESS;
   }
 
-  private void transferAll(PlayerIdentifier.Result result, ProxyAddress address) {
+  private void transferAll(PlayerIdentifier.Result result, Address address) {
     for (VelocityClusterPlayer clusterPlayer : result.players()) {
-      clusterPlayer.transfer(address.ip(), address.port()).exceptionally(ex -> {
+      clusterPlayer.transfer(address.hostname(), address.port()).exceptionally(ex -> {
         handleTransferError(clusterPlayer, ex);
         return null;
       });
@@ -173,5 +203,36 @@ public class TransferCommand implements BuiltinCommand {
             .filter(s -> s.equalsIgnoreCase(inputProxyId))
             .findFirst()
             .orElse(inputProxyId);
+  }
+
+  private record Address(String hostname, int port) {
+
+    public static Address fromProxyAddress(ProxyAddress proxyAddress) {
+      return new Address(proxyAddress.ip(), proxyAddress.port());
+    }
+
+    public boolean proxyAddressEquals(ProxyAddress proxyAddress) {
+      return port == proxyAddress.port() && hostname.equalsIgnoreCase(proxyAddress.ip());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Address address = (Address) o;
+      return port == address.port && hostname.equalsIgnoreCase(address.hostname);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(hostname.toLowerCase(), port);
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return hostname + ":" + port;
+    }
   }
 }

--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -144,18 +144,6 @@ public class CtdConfigMigrations {
 
         // [advanced]
         migration(
-            "Whether the proxy should cache Mojang profile results (reduces API load and improves login speed).\n"
-                + " This may also resolve random occurrences where the user is flagged for an invalid session.",
-            "advanced.cache-player-profile-result",
-            false
-        ),
-        migration(
-            "How long to cache Mojang profile results in minutes.\n"
-                + " Cannot be less than 1 minute. The default is 1440 minutes (24 hours).",
-            "advanced.cache-profile-expiry-minutes",
-            1440
-        ),
-        migration(
             "Enables the execution of illegal characters in chat and only allows\n"
                 + " or denies illegal characters that are executed through the proxy.",
             "advanced.allow-illegal-characters-in-chat",

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/data/VelocityGetPlayerPing.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/data/VelocityGetPlayerPing.java
@@ -18,11 +18,12 @@
 package com.velocityctd.proxy.redis.data;
 
 import com.velocityctd.proxy.redis.transaction.TransactionData;
+import java.util.UUID;
 
 /**
  * Data record representing a request to get the ping of a player.
  *
- * @param username the username of the player to get the ping of
+ * @param uniqueId the player's unique ID
  */
-public record VelocityGetPlayerPing(String username) implements TransactionData<Long> {
+public record VelocityGetPlayerPing(UUID uniqueId) implements TransactionData<Long> {
 }

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/data/VelocitySwitchServer.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/data/VelocitySwitchServer.java
@@ -17,11 +17,13 @@
 
 package com.velocityctd.proxy.redis.data;
 
+import java.util.UUID;
+
 /**
  * Data record used to switch a player to a specific server.
  *
- * @param username the username of the player
+ * @param uniqueId the player's unique ID
  * @param serverName the name of the target server
  */
-public record VelocitySwitchServer(String username, String serverName) {
+public record VelocitySwitchServer(UUID uniqueId, String serverName) {
 }

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/handler/RouteHandlerRegistry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/handler/RouteHandlerRegistry.java
@@ -53,7 +53,7 @@ public enum RouteHandlerRegistry {
    * Handles the {@link VelocitySwitchServer} data by switching the player to the specified server.
    */
   VELOCITY_SWITCH_SERVER(VelocitySwitchServer.class, (server, data) -> {
-    final ConnectedPlayer player = server.getPlayer(data.username()).orElse(null);
+    final ConnectedPlayer player = server.getPlayer(data.uniqueId()).orElse(null);
     if (player == null) {
       return;
     }

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/handler/TransactionHandlerRegistry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/handler/TransactionHandlerRegistry.java
@@ -48,7 +48,7 @@ public enum TransactionHandlerRegistry {
    * Handles the {@link VelocityGetPlayerPing} transaction by replying with the player's ping.
    */
   VELOCITY_GET_PLAYER_PING(VelocityGetPlayerPing.class, (server, data) -> {
-    final ConnectedPlayer player = server.getPlayer(data.username()).orElse(null);
+    final ConnectedPlayer player = server.getPlayer(data.uniqueId()).orElse(null);
     if (player == null) {
       return null;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -46,6 +46,7 @@ import com.velocityctd.proxy.queue.VelocityQueueManager;
 import com.velocityctd.proxy.redis.VelocityRedis;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.Command;
+import com.velocitypowered.api.command.CommandMeta;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyPreShutdownEvent;
 import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
@@ -830,9 +831,13 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   }
 
   private void unregisterCommand(final String command) {
-    if (commandManager.getCommandMeta(command) != null
-        && Objects.requireNonNull(commandManager.getCommandMeta(command)).getPlugin() instanceof VelocityCommandManager) {
-      commandManager.unregister(command);
+    CommandMeta meta = commandManager.getCommandMeta(command);
+    if (meta != null) {
+      if (meta.getPlugin() == VelocityVirtualPlugin.INSTANCE) {
+        commandManager.unregister(meta);
+      } else {
+        LOGGER.debug("Could not unregister command /{}, command not registered by Velocity.", command);
+      }
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -711,16 +711,6 @@ public final class VelocityConfiguration implements ProxyConfig {
   }
 
   @Override
-  public boolean isCachePlayerProfileResultEnabled() {
-    return advanced.isCachePlayerProfileResultEnabled();
-  }
-
-  @Override
-  public int getProfileCacheExpiryMinutes() {
-    return advanced.getProfileCacheExpiryMinutes();
-  }
-
-  @Override
   public int getCompressionThreshold() {
     return advanced.getCompressionThreshold();
   }
@@ -2191,18 +2181,6 @@ public final class VelocityConfiguration implements ProxyConfig {
   private static final class Advanced {
 
     /**
-     * Whether to cache player profile results retrieved from Mojang session servers.
-     */
-    @Expose
-    private boolean cachePlayerProfileResult = false;
-
-    /**
-     * How long (in minutes) cached player profiles are retained before expiring.
-     */
-    @Expose
-    private int profileCacheExpiryMinutes = 1440;
-
-    /**
      * The size threshold (in bytes) at which packets are compressed.
      * -1 disables compression, 0 compresses all packets.
      */
@@ -2374,8 +2352,6 @@ public final class VelocityConfiguration implements ProxyConfig {
 
     private Advanced(final CommentedConfig config) {
       if (config != null) {
-        this.cachePlayerProfileResult = config.getOrElse("cache-player-profile-result", false);
-        this.profileCacheExpiryMinutes = config.getOrElse("cache-profile-expiry-minutes", 1440);
         this.compressionThreshold = config.getIntOrElse("compression-threshold", 256);
         this.compressionLevel = config.getIntOrElse("compression-level", -1);
         this.loginRatelimit = config.getIntOrElse("login-ratelimit", 3000);
@@ -2412,14 +2388,6 @@ public final class VelocityConfiguration implements ProxyConfig {
           .serialize(MiniMessage.miniMessage().deserialize(this.serverBrand));
       this.fallbackVersionPingAsString = LegacyComponentSerializer.legacySection()
           .serialize(MiniMessage.miniMessage().deserialize(this.fallbackVersionPing));
-    }
-
-    public boolean isCachePlayerProfileResultEnabled() {
-      return this.cachePlayerProfileResult;
-    }
-
-    public int getProfileCacheExpiryMinutes() {
-      return this.profileCacheExpiryMinutes;
     }
 
     public int getCompressionThreshold() {
@@ -2529,9 +2497,7 @@ public final class VelocityConfiguration implements ProxyConfig {
     @Override
     public String toString() {
       return "Advanced{"
-          + "cachePlayerProfileResult=" + cachePlayerProfileResult
-          + ", profileCacheExpiryMinutes=" + profileCacheExpiryMinutes
-          + ", compressionThreshold=" + compressionThreshold
+          + "compressionThreshold=" + compressionThreshold
           + ", compressionLevel=" + compressionLevel
           + ", loginRatelimit=" + loginRatelimit
           + ", connectionTimeout=" + connectionTimeout

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -229,15 +229,6 @@ examplealias = [
 ]
 
 [advanced]
-# Whether the proxy should cache Mojang profile results (reduces API load and improves login speed).
-# This may also resolve random occurrences where the user is flagged for an invalid session.
-cache-player-profile-result = false
-
-# How long to cache Mojang profile results in minutes.
-# Cannot be less than 1 minute. The default is 1440 minutes,
-# which is 24 hours.
-cache-profile-expiry-minutes = 1440
-
 # How large a Minecraft packet has to be before we compress it. Setting this to zero will
 # compress all packets, and setting it to -1 will disable compression entirely.
 compression-threshold = 256


### PR DESCRIPTION
- clean up config by removing caching options
- make all redis packets use UUID as player identifiers (some were using username, others were using UUID before)
- fix unregistering commands with `/velocity reload`
- add hostname+port support with `/transfer <+server/-proxy/player> <hostname> <port>`