### PR TITLE
Update github publishing pipeline

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,9 +4,7 @@
 name: Java CI with Gradle
 on:
   push:
-    branches:
-      - libdeflate
-      - dev
+  pull_request:
 
 jobs:
   build:
@@ -52,9 +50,17 @@ jobs:
         NEW_BUILD=$((LATEST_BUILD + 1))
         
         echo "tag=build-$NEW_BUILD" >> $GITHUB_OUTPUT
+        echo "build_nr=$NEW_BUILD" >> $GITHUB_OUTPUT
         echo "Generated tag: build-$NEW_BUILD"
         echo "Previous highest build: $LATEST_BUILD"
         echo "New build number: $NEW_BUILD"
+
+    - name: Rename Jar
+      if: github.ref == 'refs/heads/libdeflate'
+      run: |
+        JAR=$(ls proxy/build/libs/velocity-proxy-*-all.jar)
+        VERSION=$(echo "$JAR" | sed 's|proxy/build/libs/velocity-proxy-||' | sed 's|-all\.jar||')
+        cp "$JAR" "proxy/build/libs/velocity-ctd-$VERSION-${{ steps.release_tag.outputs.build_nr }}.jar"
 
     - name: Upload Velocity
       if: github.ref == 'refs/heads/libdeflate'
@@ -63,5 +69,5 @@ jobs:
         title: "Velocity-CTD"
         automatic_release_tag: "${{ steps.release_tag.outputs.tag }}"
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        files: "*/build/libs/*.jar"
+        files: "proxy/build/libs/velocity-ctd-*-${{ steps.release_tag.outputs.build_nr }}.jar"
         prerelease: false


### PR DESCRIPTION
This PR does two things:
- The project is now built (not published) on ANY commit and PR change on any branch, ensuring any PR and branch will pass the checkstyle checks.
- Instead of publishing all jars built, which is unnecessary (as we are going to publish other artifacts like `api` through maven), we only publish the server jar (`proxy/build/libs/velocity-proxy-3.5.0-SNAPSHOT-all.jar`, or whatever version). We now upload this jar under a different name: `velocity-ctd-VERSION-TAG.jar`, e.g. `velocity-ctd-3.5.0-SNAPSHOT-195.jar`. This is in-line with how Velocity distributes their server jar [here](https://papermc.io/downloads/velocity), the current version is `velocity-3.5.0-SNAPSHOT-595.jar` with 595 being the build nr/tag.