### PR TITLE
Fix stale queue entries after force-kill by tracking offline timestamps

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueue.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueue.java
@@ -203,6 +203,20 @@ public final class RedisVelocityQueue extends VelocityQueue {
   }
 
   /**
+   * Applies an OFFLINE_CHANGE sync received from another proxy, updating the entry's
+   * offline timestamp and timeout so the master's depot snapshot stays accurate.
+   */
+  @ApiStatus.Internal
+  void applyOfflineChange(UUID uuid, long offlineSinceMs, int offlineTimeoutSeconds) {
+    VelocityQueueEntry entry = getEntry(uuid);
+    if (entry != null) {
+      entry.offlineSinceMs = offlineSinceMs;
+      entry.offlineTimeoutSeconds = offlineTimeoutSeconds;
+      persistAsync();
+    }
+  }
+
+  /**
    * Persists this queue's state to the Redis depot asynchronously.
    * Only executed when this proxy is currently the master.
    */

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueEntry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueEntry.java
@@ -97,6 +97,17 @@ public final class RedisVelocityQueueEntry extends VelocityQueueEntry {
   }
 
   /**
+   * Publishes an {@code OFFLINE_CHANGE} sync packet so all proxies update this entry's
+   * offline timestamp and timeout, which drives correct removal scheduling after a restart.
+   */
+  @Override
+  protected void publishOfflineChange() {
+    server.getRedis().publish(VelocityQueueSync.offlineChange(
+        getQueue().getName(), getUniqueId(), this.offlineSinceMs, this.offlineTimeoutSeconds
+    ));
+  }
+
+  /**
    * Updates this entry's mutable fields from a {@code WAITING_CHANGE} sync packet received
    * from another proxy.
    *

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
@@ -25,6 +25,7 @@ import com.velocityctd.proxy.queue.redis.depot.VelocityQueueDepotService;
 import com.velocityctd.proxy.queue.redis.packet.VelocityQueueSync;
 import com.velocityctd.proxy.queue.util.QueueComponents;
 import com.velocityctd.proxy.redis.data.VelocityActionBar;
+import com.velocitypowered.api.scheduler.ScheduledTask;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
@@ -168,10 +169,11 @@ public final class RedisVelocityQueueManager extends VelocityQueueManager {
           delayMs = Math.max(0, remainingMs);
         }
 
-        server.getScheduler()
+        ScheduledTask task = server.getScheduler()
             .buildTask(VelocityVirtualPlugin.INSTANCE, () -> removePlayerEntirely(uuid))
             .delay(delayMs, TimeUnit.MILLISECONDS)
             .schedule();
+        pendingTimeoutTasks.put(uuid, task);
       }
     }
   }

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
@@ -170,7 +170,11 @@ public final class RedisVelocityQueueManager extends VelocityQueueManager {
         }
 
         ScheduledTask task = server.getScheduler()
-            .buildTask(VelocityVirtualPlugin.INSTANCE, () -> removePlayerEntirely(uuid))
+            .buildTask(VelocityVirtualPlugin.INSTANCE, () -> {
+              if (!isPlayerOnline(uuid)) {
+                removePlayerEntirely(uuid);
+              }
+            })
             .delay(delayMs, TimeUnit.MILLISECONDS)
             .schedule();
         pendingTimeoutTasks.put(uuid, task);

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
@@ -51,6 +52,8 @@ public final class RedisVelocityQueueManager extends VelocityQueueManager {
 
   @Override
   protected void postInitialize() {
+    scheduleOfflineRemovals();
+
     server.getRedis().addReconnectListener(() ->
         server.getScheduler()
             .buildTask(VelocityVirtualPlugin.INSTANCE, this::reloadFromRedis)
@@ -125,7 +128,51 @@ public final class RedisVelocityQueueManager extends VelocityQueueManager {
       case STATE_CHANGE -> queue.applyStateChange(sync.newState());
       case STATUS_CHANGE -> queue.applyStatusChange(sync.newStatus());
       case WAITING_CHANGE -> queue.applyWaitingChange(sync);
+      case OFFLINE_CHANGE -> queue.applyOfflineChange(
+          sync.playerUuid(), sync.offlineSinceMs(), sync.offlineTimeoutSeconds());
       default -> throw new IllegalStateException("Unknown action " + sync.action() + ".");
+    }
+  }
+
+  /**
+   * Schedules removal of offline players that were loaded from the depot at startup.
+   *
+   * <p>For each offline player in the just-loaded queues:
+   * <ul>
+   *   <li>If {@code offlineSinceMs == 0}: the proxy was force-killed and no disconnect was
+   *       recorded - the player is removed immediately since we cannot know how long they have
+   *       been offline.</li>
+   *   <li>If {@code offlineSinceMs > 0}: the remaining timeout is calculated from the stored
+   *       disconnect time and the player is removed once that window expires.</li>
+   * </ul>
+   * Online players are skipped; the normal session lifecycle handles them.</p>
+   */
+  private void scheduleOfflineRemovals() {
+    for (VelocityQueue queue : queues.values()) {
+      for (VelocityQueueEntry entry : queue.getEntries()) {
+        if (isPlayerOnline(entry.getUniqueId())) {
+          continue;
+        }
+
+        long offlineSinceMs = entry.getOfflineSinceMs();
+        int timeoutSeconds = entry.getOfflineTimeoutSeconds();
+        UUID uuid = entry.getUniqueId();
+
+        long delayMs;
+        if (offlineSinceMs == 0) {
+          // Force-kill scenario: disconnect was never recorded, remove immediately.
+          delayMs = 0;
+        } else {
+          long elapsedMs = System.currentTimeMillis() - offlineSinceMs;
+          long remainingMs = (long) timeoutSeconds * 1000 - elapsedMs;
+          delayMs = Math.max(0, remainingMs);
+        }
+
+        server.getScheduler()
+            .buildTask(VelocityVirtualPlugin.INSTANCE, () -> removePlayerEntirely(uuid))
+            .delay(delayMs, TimeUnit.MILLISECONDS)
+            .schedule();
+      }
     }
   }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueEntry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueEntry.java
@@ -46,6 +46,18 @@ public class VelocityQueueEntry implements QueueEntry {
   protected volatile boolean queueBypass;
 
   /**
+   * Epoch-millisecond timestamp when this player disconnected while queued, or 0 if the
+   * player is currently online or if the disconnect was not recorded (e.g. force-kill).
+   */
+  protected volatile long offlineSinceMs = 0;
+
+  /**
+   * The timeout in seconds that was active at the time of disconnect, or 0 if unknown.
+   * Only meaningful when {@link #offlineSinceMs} is non-zero.
+   */
+  protected volatile int offlineTimeoutSeconds = 0;
+
+  /**
    * Injected after construction or deserialization.
    */
   protected transient VelocityServer server;
@@ -243,6 +255,42 @@ public class VelocityQueueEntry implements QueueEntry {
           .schedule();
       queue.dequeue(this.uniqueId);
     }
+  }
+
+  public long getOfflineSinceMs() {
+    return offlineSinceMs;
+  }
+
+  public int getOfflineTimeoutSeconds() {
+    return offlineTimeoutSeconds;
+  }
+
+  /**
+   * Records that this player has gone offline with the given timeout. Propagates the
+   * change to other proxies via {@link #publishOfflineChange()}.
+   */
+  public void setOffline(long sinceMs, int timeoutSeconds) {
+    this.offlineSinceMs = sinceMs;
+    this.offlineTimeoutSeconds = timeoutSeconds;
+    publishOfflineChange();
+  }
+
+  /**
+   * Clears offline tracking state when a player reconnects within the timeout window.
+   * Propagates the change to other proxies via {@link #publishOfflineChange()}.
+   */
+  public void clearOffline() {
+    this.offlineSinceMs = 0;
+    this.offlineTimeoutSeconds = 0;
+    publishOfflineChange();
+  }
+
+  /**
+   * Hook for subclasses to broadcast offline-state changes to other proxies.
+   * No-op in local (single-proxy) mode.
+   */
+  protected void publishOfflineChange() {
+    // no-op in local mode
   }
 
   /**

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
@@ -84,7 +84,7 @@ public class VelocityQueueManager implements QueueManager {
    * Holds all scheduled tasks to remove players from all queues (after a player's timeout).
    * Stored such that they can be cancelled on join.
    */
-  private final Map<UUID, ScheduledTask> pendingTimeoutTasks = new ConcurrentHashMap<>();
+  protected final Map<UUID, ScheduledTask> pendingTimeoutTasks = new ConcurrentHashMap<>();
 
   private @Nullable ScheduledTask transferTask;
   private @Nullable ScheduledTask actionBarTask;

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
@@ -328,7 +328,11 @@ public class VelocityQueueManager implements QueueManager {
       });
 
       ScheduledTask task = server.getScheduler()
-          .buildTask(VelocityVirtualPlugin.INSTANCE, () -> removePlayerEntirely(playerUniqueId))
+          .buildTask(VelocityVirtualPlugin.INSTANCE, () -> {
+            if (!isPlayerOnline(playerUniqueId)) {
+              removePlayerEntirely(playerUniqueId);
+            }
+          })
           .delay(timeout, TimeUnit.SECONDS)
           .schedule();
 

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
@@ -283,6 +283,13 @@ public class VelocityQueueManager implements QueueManager {
     ScheduledTask timeoutTask = pendingTimeoutTasks.remove(player.getUniqueId());
     if (timeoutTask != null) {
       timeoutTask.cancel();
+      // Player reconnected within the timeout window -> Clear the offline state from all entries.
+      queues.values().forEach(q -> {
+        VelocityQueueEntry entry = q.getEntry(player.getUniqueId());
+        if (entry != null) {
+          entry.clearOffline();
+        }
+      });
     }
   }
 
@@ -309,6 +316,17 @@ public class VelocityQueueManager implements QueueManager {
     } else {
       LOGGER.debug("Removing player {} from all queues in {} second(s) (has timeout).", player.getUsername(), timeout);
       UUID playerUniqueId = player.getUniqueId();
+
+      // Record when the player went offline and their timeout so that, if all proxies are
+      // force-killed, the next startup can compute the correct remaining removal delay.
+      long offlineSince = System.currentTimeMillis();
+      queues.values().forEach(q -> {
+        VelocityQueueEntry entry = q.getEntry(playerUniqueId);
+        if (entry != null) {
+          entry.setOffline(offlineSince, timeout);
+        }
+      });
+
       ScheduledTask task = server.getScheduler()
           .buildTask(VelocityVirtualPlugin.INSTANCE, () -> removePlayerEntirely(playerUniqueId))
           .delay(timeout, TimeUnit.SECONDS)

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/redis/packet/VelocityQueueSync.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/redis/packet/VelocityQueueSync.java
@@ -44,7 +44,9 @@ public record VelocityQueueSync(
     int connectionAttempts,
     int updatedPriority,
     boolean updatedFullBypass,
-    boolean updatedQueueBypass
+    boolean updatedQueueBypass,
+    long offlineSinceMs,
+    int offlineTimeoutSeconds
 ) {
 
   /**
@@ -55,7 +57,8 @@ public record VelocityQueueSync(
     DEQUEUE,
     STATE_CHANGE,
     STATUS_CHANGE,
-    WAITING_CHANGE
+    WAITING_CHANGE,
+    OFFLINE_CHANGE
   }
 
   /**
@@ -64,7 +67,7 @@ public record VelocityQueueSync(
   public static VelocityQueueSync enqueue(String serverName, UUID uuid, String username, int priority,
                                            boolean fullBypass, boolean queueBypass) {
     return new VelocityQueueSync(Action.ENQUEUE, serverName, uuid, username, priority, fullBypass,
-        queueBypass, null, null, false, 0, 0, false, false);
+        queueBypass, null, null, false, 0, 0, false, false, 0L, 0);
   }
 
   /**
@@ -72,7 +75,7 @@ public record VelocityQueueSync(
    */
   public static VelocityQueueSync dequeue(String serverName, UUID uuid) {
     return new VelocityQueueSync(Action.DEQUEUE,
-        serverName, uuid, null, 0, false, false, null, null, false, 0, 0, false, false);
+        serverName, uuid, null, 0, false, false, null, null, false, 0, 0, false, false, 0L, 0);
   }
 
   /**
@@ -80,7 +83,7 @@ public record VelocityQueueSync(
    */
   public static VelocityQueueSync stateChange(String serverName, QueueState state) {
     return new VelocityQueueSync(Action.STATE_CHANGE, serverName, null, null, 0, false, false,
-        state, null, false, 0, 0, false, false);
+        state, null, false, 0, 0, false, false, 0L, 0);
   }
 
   /**
@@ -88,7 +91,7 @@ public record VelocityQueueSync(
    */
   public static VelocityQueueSync statusChange(String serverName, ServerStatus status) {
     return new VelocityQueueSync(Action.STATUS_CHANGE, serverName, null, null, 0, false, false,
-        null, status, false, 0, 0, false, false);
+        null, status, false, 0, 0, false, false, 0L, 0);
   }
 
   /**
@@ -99,6 +102,15 @@ public record VelocityQueueSync(
                                                   boolean updatedFullBypass, boolean updatedQueueBypass) {
     return new VelocityQueueSync(Action.WAITING_CHANGE, serverName, uuid, null, 0, false, false,
         null, null, waitingForConnection, connectionAttempts, updatedPriority,
-        updatedFullBypass, updatedQueueBypass);
+        updatedFullBypass, updatedQueueBypass, 0L, 0);
+  }
+
+  /**
+   * Creates an OFFLINE_CHANGE sync to record when a player goes offline (or clears on reconnect).
+   */
+  public static VelocityQueueSync offlineChange(String serverName, UUID uuid,
+                                                long offlineSinceMs, int offlineTimeoutSeconds) {
+    return new VelocityQueueSync(Action.OFFLINE_CHANGE, serverName, uuid, null, 0, false, false,
+        null, null, false, 0, 0, false, false, offlineSinceMs, offlineTimeoutSeconds);
   }
 }


### PR DESCRIPTION
When all proxies are force-killed, `onPlayerDisconnect()` never fires, leaving offline players stranded in the Redis depot queue with no recorded disconnect time. Previously, the reaper only cleared them one-by-one as they reached position 1 (sendDelay x position seconds per player).

Now, when a player disconnects with a timeout grace period, their disconnect timestamp and timeout duration are stored on the queue entry. On startup, `scheduleOfflineRemovals()` removes any offline player whose `offlineSinceMs == 0` (force-kill: disconnect was never recorded) immediately, and correctly reschedules removal for legitimately timed-out players based on remaining time.