### PR TITLE
Add decompressed-bytes-per-second rate limit, update packet limiter defaults

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2319,7 +2319,7 @@ public final class VelocityConfiguration implements ProxyConfig {
    * @param bytesAfterDecompression the maximum number of decompressed bytes per second allowed
    */
   public record PacketLimiterConfig(int interval, int pps, int bytes, int bytesAfterDecompression) {
-    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, 500, -1, -1);
+    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, -1, -1, 10485760);
 
     /**
      * returns a PacketLimiterConfig from a config section, or the default if the section is null.

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2319,7 +2319,7 @@ public final class VelocityConfiguration implements ProxyConfig {
    * @param bytesAfterDecompression the maximum number of decompressed bytes per second allowed
    */
   public record PacketLimiterConfig(int interval, int pps, int bytes, int bytesAfterDecompression) {
-    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, -1, -1, 10485760);
+    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, -1, -1, 5242880);
 
     /**
      * returns a PacketLimiterConfig from a config section, or the default if the section is null.

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2313,12 +2313,13 @@ public final class VelocityConfiguration implements ProxyConfig {
   /**
    * Configuration for packet limiting.
    *
-   * @param interval the interval in seconds to measure packets over
-   * @param pps      the maximum number of packets per second allowed
-   * @param bytes    the maximum number of bytes per second allowed
+   * @param interval                the interval in seconds to measure packets over
+   * @param pps                     the maximum number of packets per second allowed
+   * @param bytes                   the maximum number of compressed bytes per second allowed
+   * @param bytesAfterDecompression the maximum number of decompressed bytes per second allowed
    */
-  public record PacketLimiterConfig(int interval, int pps, int bytes) {
-    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, 500, -1);
+  public record PacketLimiterConfig(int interval, int pps, int bytes, int bytesAfterDecompression) {
+    public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, 500, -1, -1);
 
     /**
      * returns a PacketLimiterConfig from a config section, or the default if the section is null.
@@ -2331,7 +2332,8 @@ public final class VelocityConfiguration implements ProxyConfig {
         return new PacketLimiterConfig(
             config.getIntOrElse("interval", DEFAULT.interval()),
             config.getIntOrElse("packets-per-second", DEFAULT.pps()),
-            config.getIntOrElse("bytes-per-second", DEFAULT.bytes())
+            config.getIntOrElse("bytes-per-second", DEFAULT.bytes()),
+            config.getIntOrElse("decompressed-bytes-per-second", DEFAULT.bytesAfterDecompression())
         );
       } else {
         return DEFAULT;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -40,7 +40,9 @@ import com.velocitypowered.proxy.connection.client.InitialInboundConnection;
 import com.velocitypowered.proxy.connection.client.InitialLoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
 import com.velocitypowered.proxy.network.Connections;
+import com.velocitypowered.proxy.network.limiter.SimpleBytesPerSecondLimiter;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.VelocityConnectionEvent;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCipherDecoder;
@@ -622,6 +624,14 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
         channel.pipeline().remove(FRAME_ENCODER);
         channel.pipeline().addBefore(MINECRAFT_DECODER, COMPRESSION_DECODER, decoder);
         channel.pipeline().addBefore(MINECRAFT_ENCODER, COMPRESSION_ENCODER, encoder);
+
+        var packetLimiterConfig = server.getConfiguration().getPacketLimiterConfig();
+        if (minecraftDecoder.getDirection() == ProtocolUtils.Direction.SERVERBOUND
+            && packetLimiterConfig.interval() > 0
+            && packetLimiterConfig.bytesAfterDecompression() > 0) {
+          decoder.setPacketLimiter(new SimpleBytesPerSecondLimiter(
+              -1, packetLimiterConfig.bytesAfterDecompression(), packetLimiterConfig.interval()));
+        }
 
         channel.pipeline().fireUserEventTriggered(VelocityConnectionEvent.COMPRESSION_ENABLED);
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
@@ -77,7 +77,7 @@ public class ServerChannelInitializer extends ChannelInitializer<Channel> {
     int configuredPacketsPerSecond = packetLimiterConfig.pps();
     int configuredBytes = packetLimiterConfig.bytes();
 
-    if (configuredInterval > 0 && (configuredBytes > 0 ||  configuredPacketsPerSecond > 0)) {
+    if (configuredInterval > 0 && (configuredBytes > 0 || configuredPacketsPerSecond > 0)) {
       ch.pipeline().get(MinecraftVarintFrameDecoder.class).setPacketLimiter(
           new SimpleBytesPerSecondLimiter(configuredPacketsPerSecond, configuredBytes, configuredInterval)
       );

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -22,11 +22,14 @@ import static com.velocitypowered.natives.util.MoreByteBufUtils.preferredBuffer;
 import static com.velocitypowered.proxy.protocol.util.NettyPreconditions.checkFrame;
 
 import com.velocitypowered.natives.compression.VelocityCompressor;
+import com.velocitypowered.proxy.network.limiter.PacketLimiter;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import com.velocitypowered.proxy.util.except.QuietDecoderException;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Decompresses a Minecraft packet.
@@ -51,6 +54,8 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
   private final ProtocolUtils.Direction direction;
   private int threshold;
   private final VelocityCompressor compressor;
+  @Nullable
+  private PacketLimiter packetLimiter;
 
   /**
    * Creates a new {@code MinecraftCompressDecoder} with the specified compression {@code threshold}.
@@ -76,6 +81,10 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
       }
 
       // This message is not compressed.
+      if (packetLimiter != null && !packetLimiter.account(in.readableBytes())) {
+        throw new QuietDecoderException("Rate limit exceeded while processing packets for %s"
+            .formatted(ctx.channel().remoteAddress()));
+      }
       out.add(in.retain());
       return;
     }
@@ -102,6 +111,10 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
       compressor.inflate(compatibleIn, uncompressed, claimedUncompressedSize);
       checkFrame(uncompressed.writerIndex() == claimedUncompressedSize,
               "Decompressed size %s does not match claimed uncompressed size %s", uncompressed.writerIndex(), claimedUncompressedSize);
+      if (packetLimiter != null && !packetLimiter.account(claimedUncompressedSize)) {
+        throw new QuietDecoderException("Rate limit exceeded while processing packets for %s"
+            .formatted(ctx.channel().remoteAddress()));
+      }
       out.add(uncompressed);
     } catch (Exception e) {
       uncompressed.release();
@@ -118,5 +131,9 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
 
   public void setThreshold(int threshold) {
     this.threshold = threshold;
+  }
+
+  public void setPacketLimiter(@Nullable PacketLimiter packetLimiter) {
+    this.packetLimiter = packetLimiter;
   }
 }

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -165,7 +165,7 @@ override-server-command-usage = false
 interval = 7
 packets-per-second = -1
 bytes-per-second = -1
-decompressed-bytes-per-second = 10485760
+decompressed-bytes-per-second = 5242880
 
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -165,6 +165,7 @@ override-server-command-usage = false
 interval = 7
 packets-per-second = 500
 bytes-per-second = -1
+decompressed-bytes-per-second = -1
 
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -163,9 +163,9 @@ override-server-command-usage = false
 
 [packet-limiter]
 interval = 7
-packets-per-second = 500
+packets-per-second = -1
 bytes-per-second = -1
-decompressed-bytes-per-second = -1
+decompressed-bytes-per-second = 10485760
 
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value


### PR DESCRIPTION
The existing rate limiter of 500 packets/sec caused quite some legitimate connections to be killed, especially clients with some "loud" mods (that seemingly send lots of plugin messages).

This rate limit was introduced to avoid decompression attacks, where the proxy was killed because of being out of memory after receiving lots of small packets that allocate large buffers. A rate limit targeting what the attackers were targeting makes more sense here, this PR allows a rate limiter to be configured that limits the _decompressed_ bytes per second. With a new default of 10 MiB per second, any legitimate clients should really never hit this, and the proxy should be able to handle a burst of 10 MiB * 7 seconds with ease. Any higher than that and the connection will be disconnected.