### PR TITLE
Hostname/Plugin Messages Length Limit Increase/Removal.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -38,7 +38,6 @@ import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
 import com.velocitypowered.proxy.connection.backend.BungeeCordMessageResponder;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
-import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants;
 import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackResponseBundle;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.StateRegistry;
@@ -313,12 +312,10 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
   public boolean handle(PluginMessagePacket packet) {
     // Handling an edge case, when a packet with FML client handshake (state COMPLETE)
     // arrives after JoinGame packet from destination server
-    VelocityServerConnection serverConn =
-        (player.getConnectedServer() == null
-            && packet.getChannel().equals(
-            LegacyForgeConstants.FORGE_LEGACY_HANDSHAKE_CHANNEL))
-            ? player.getConnectionInFlight() : player.getConnectedServer();
-
+    final VelocityServerConnection connected = player.getConnectedServer();
+    final VelocityServerConnection serverConn =
+        connected != null ? connected : player.getConnectionInFlight();
+    
     MinecraftConnection backendConn = serverConn != null ? serverConn.getConnection() : null;
     if (serverConn != null && backendConn != null) {
       if (backendConn.getState() != StateRegistry.PLAY) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/LegacyPingDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/LegacyPingDecoder.java
@@ -57,13 +57,20 @@ public class LegacyPingDecoder extends ByteToMessageDecoder {
       }
 
       short next = in.readUnsignedByte();
-      if (next == 1 && !in.isReadable()) {
-        out.add(new LegacyPingPacket(LegacyMinecraftPingVersion.MINECRAFT_1_4));
-        return;
+      if (next == 1) {
+        if (!in.isReadable()) {
+          out.add(new LegacyPingPacket(LegacyMinecraftPingVersion.MINECRAFT_1_4));
+          return;
+        }
+        if (in.getUnsignedByte(in.readerIndex()) == 0xFA) {
+          out.add(readExtended16Data(in));
+          return;
+        }
       }
 
-      // We got a 1.6.x ping. Let's chomp off the stuff we don't need.
-      out.add(readExtended16Data(in));
+      // Not a legacy ping. Reset and let the modern decoder handle it.
+      in.readerIndex(originalReaderIndex);
+      ctx.pipeline().remove(this);
     } else if (first == 0x02 && in.isReadable()) {
       in.skipBytes(in.readableBytes());
       out.add(new LegacyHandshakePacket());

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/HandshakePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/HandshakePacket.java
@@ -17,8 +17,6 @@
 
 package com.velocitypowered.proxy.protocol.packet;
 
-import static com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN;
-
 import com.velocitypowered.api.network.HandshakeIntent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
@@ -27,11 +25,6 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
 
 public class HandshakePacket implements MinecraftPacket {
-
-  // This size was chosen to ensure Forge clients can still connect even with very long hostnames.
-  // While DNS technically allows any character to be used, in practice ASCII is used.
-
-  private static final int MAXIMUM_HOSTNAME_LENGTH = 255 + HANDSHAKE_HOSTNAME_TOKEN.length() + 1;
 
   private ProtocolVersion protocolVersion;
 
@@ -94,7 +87,7 @@ public class HandshakePacket implements MinecraftPacket {
   public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion ignored) {
     int realProtocolVersion = ProtocolUtils.readVarInt(buf);
     this.protocolVersion = ProtocolVersion.getProtocolVersion(realProtocolVersion);
-    this.serverAddress = ProtocolUtils.readString(buf, MAXIMUM_HOSTNAME_LENGTH);
+    this.serverAddress = ProtocolUtils.readString(buf, Short.MAX_VALUE);
     this.port = buf.readUnsignedShort();
     this.nextStatus = ProtocolUtils.readVarInt(buf);
     this.intent = HandshakeIntent.getById(nextStatus);
@@ -122,7 +115,7 @@ public class HandshakePacket implements MinecraftPacket {
   @Override
   public int decodeExpectedMaxLength(ByteBuf buf, ProtocolUtils.Direction direction,
                                      ProtocolVersion version) {
-    return 9 + (MAXIMUM_HOSTNAME_LENGTH * 3);
+    return 9 + (Short.MAX_VALUE * 3);
   }
 
   @Override


### PR DESCRIPTION
Clone of https://github.com/SendableMetatype/Velocity

Support for https://github.com/SendableMetatype/EduGeyser
-- NOTE: I AM NEW TO GITHUB PRs in general, so don't expect me to be perfect at this.
This PR fixes handshake hostname length limit (especially for EduGeyser and my server in general, as the domain can be very long, so now the EDU connection is dropped. Some plugins can make forwarding data very long and cause it to be dropped.
This PR also fixes the long plugin messages bug that causes the data and the connection in general to be silently dropped for being too long.