### PR TITLE
Optimize hot/semi-hot paths for UUID gen.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ slf4j = "org.slf4j:slf4j-api:2.0.18"
 snakeyaml = "org.yaml:snakeyaml:2.6"
 spotbugs-annotations = "com.github.spotbugs:spotbugs-annotations:4.9.8"
 terminalconsoleappender = "net.minecrell:terminalconsoleappender:1.3.0"
+uuid-creator = "com.github.f4b6a3:uuid-creator:6.1.1"
 
 [bundles]
 configurate3 = ["configurate3-hocon", "configurate3-yaml", "configurate3-gson"]

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -169,6 +169,7 @@ dependencies {
     implementation(libs.lmbda)
     implementation(libs.asm)
     implementation(libs.bundles.flare)
+    implementation(libs.uuid.creator)
     compileOnly(libs.spotbugs.annotations)
     compileOnly(libs.auto.service.annotations)
     testImplementation(libs.mockito)

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/packet/DataPacket.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/packet/DataPacket.java
@@ -17,9 +17,9 @@
 
 package com.velocityctd.proxy.redis.packet;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -78,7 +78,7 @@ public final class DataPacket {
    * @param <T> the type of the payload
    */
   private <T> DataPacket(@NotNull String serializedPayload, @NotNull T rawPayload) {
-    this.packetId = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
+    this.packetId = UuidCreator.getTimeOrderedEpochFast();
     this.payload = serializedPayload;
     this.payloadType = rawPayload.getClass().getName();
     this.rawPayload = rawPayload;

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/packet/DataPacket.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/packet/DataPacket.java
@@ -19,6 +19,7 @@ package com.velocityctd.proxy.redis.packet;
 
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -77,7 +78,7 @@ public final class DataPacket {
    * @param <T> the type of the payload
    */
   private <T> DataPacket(@NotNull String serializedPayload, @NotNull T rawPayload) {
-    this.packetId = UUID.randomUUID();
+    this.packetId = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
     this.payload = serializedPayload;
     this.payloadType = rawPayload.getClass().getName();
     this.rawPayload = rawPayload;

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/transaction/Transaction.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/transaction/Transaction.java
@@ -22,6 +22,7 @@ import com.velocityctd.proxy.redis.packet.PacketSerializer;
 import com.velocityctd.proxy.redis.provider.RedisProvider;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.jetbrains.annotations.NotNull;
@@ -90,7 +91,7 @@ public final class Transaction<T extends TransactionData<R>, R> {
    * @param sentData the data to send
    */
   private Transaction(@NotNull T sentData) {
-    this.transactionId = UUID.randomUUID();
+    this.transactionId = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
     this.sentData = sentData;
     this.responseClass = sentData.responseClass();
   }

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/transaction/Transaction.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/transaction/Transaction.java
@@ -17,12 +17,12 @@
 
 package com.velocityctd.proxy.redis.transaction;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import com.velocityctd.proxy.redis.packet.DataPacket;
 import com.velocityctd.proxy.redis.packet.PacketSerializer;
 import com.velocityctd.proxy.redis.provider.RedisProvider;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.jetbrains.annotations.NotNull;
@@ -91,7 +91,7 @@ public final class Transaction<T extends TransactionData<R>, R> {
    * @param sentData the data to send
    */
   private Transaction(@NotNull T sentData) {
-    this.transactionId = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
+    this.transactionId = UuidCreator.getTimeOrderedEpochFast();
     this.sentData = sentData;
     this.responseClass = sentData.responseClass();
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -99,8 +99,7 @@ public class ServerListPingHandler {
     String serverPingVersion = configuration.getFallbackVersionPing();
 
     for (Component s : server.getConfiguration().getMotdHover()) {
-      samplePlayers.add(new ServerPing.SamplePlayer(s, new UUID(
-            ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong())));
+      samplePlayers.add(new ServerPing.SamplePlayer(s, UUID.randomUUID()));
     }
 
     return new ServerPing(

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import net.kyori.adventure.text.Component;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -99,7 +99,8 @@ public class ServerListPingHandler {
     String serverPingVersion = configuration.getFallbackVersionPing();
 
     for (Component s : server.getConfiguration().getMotdHover()) {
-      samplePlayers.add(new ServerPing.SamplePlayer(s, UUID.randomUUID()));
+      samplePlayers.add(new ServerPing.SamplePlayer(s, new UUID(
+            ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong())));
     }
 
     return new ServerPing(
@@ -114,21 +115,19 @@ public class ServerListPingHandler {
   }
 
   private String formatVersionString(String raw, ProtocolVersion version) {
-    return parseVariables(raw, (variable) -> {
-      return switch (variable) {
-        case "protocol-min" -> ProtocolVersion.getVersionByName(
-            server.getConfiguration().getMinimumVersion()).getVersionIntroducedIn();
-        case "protocol-max" -> server.getConfiguration().getMaximumVersion()
-            .orElse(ProtocolVersion.MAXIMUM_VERSION.getMostRecentSupportedVersion());
-        case "protocol" -> version.getVersionIntroducedIn();
-        case "proxy-brand" -> server.getVersion().getName();
-        case "proxy-brand-custom" -> server.getConfiguration().getProxyBrandCustom();
-        case "proxy-version" -> server.getVersion().getVersion();
-        case "proxy-vendor" -> server.getVersion().getVendor();
-        case "player-count" -> String.valueOf(server.getClusterPlayerService().getTotalPlayerCount());
-        case "max-players" -> String.valueOf(server.getConfiguration().getShowMaxPlayers());
-        default -> null;
-      };
+    return parseVariables(raw, (variable) -> switch (variable) {
+      case "protocol-min" -> ProtocolVersion.getVersionByName(
+          server.getConfiguration().getMinimumVersion()).getVersionIntroducedIn();
+      case "protocol-max" -> server.getConfiguration().getMaximumVersion()
+          .orElse(ProtocolVersion.MAXIMUM_VERSION.getMostRecentSupportedVersion());
+      case "protocol" -> version.getVersionIntroducedIn();
+      case "proxy-brand" -> server.getVersion().getName();
+      case "proxy-brand-custom" -> server.getConfiguration().getProxyBrandCustom();
+      case "proxy-version" -> server.getVersion().getVersion();
+      case "proxy-vendor" -> server.getVersion().getVendor();
+      case "player-count" -> String.valueOf(server.getClusterPlayerService().getTotalPlayerCount());
+      case "max-players" -> String.valueOf(server.getConfiguration().getShowMaxPlayers());
+      default -> null;
     });
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -19,6 +19,7 @@ package com.velocitypowered.proxy.connection.util;
 
 import static com.velocityctd.proxy.util.ParsingUtils.parseVariables;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import com.spotify.futures.CompletableFutures;
 import com.velocityctd.proxy.cluster.VelocityClusterPlayer;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -99,7 +100,7 @@ public class ServerListPingHandler {
     String serverPingVersion = configuration.getFallbackVersionPing();
 
     for (Component s : server.getConfiguration().getMotdHover()) {
-      samplePlayers.add(new ServerPing.SamplePlayer(s, UUID.randomUUID()));
+      samplePlayers.add(new ServerPing.SamplePlayer(s, UuidCreator.getTimeOrderedEpochFast()));
     }
 
     return new ServerPing(

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -67,7 +67,7 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
 
     buf.writeFloat(sound.pitch());
 
-    sound.seed().orElseGet(() -> ThreadLocalRandom.current().nextLong());
+    buf.writeLong(sound.seed().orElseGet(() -> ThreadLocalRandom.current().nextLong()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -67,7 +67,7 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
 
     buf.writeFloat(sound.pitch());
 
-    buf.writeLong(sound.seed().orElse(ThreadLocalRandom.current().nextLong()));
+    sound.seed().orElseGet(() -> ThreadLocalRandom.current().nextLong());
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -22,13 +22,11 @@ import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import net.kyori.adventure.sound.Sound;
 import org.jetbrains.annotations.Nullable;
 
 public class ClientboundSoundEntityPacket implements MinecraftPacket {
-
-  private static final Random SEEDS_RANDOM = new Random();
 
   private Sound sound;
 
@@ -69,7 +67,7 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
 
     buf.writeFloat(sound.pitch());
 
-    buf.writeLong(sound.seed().orElse(SEEDS_RANDOM.nextLong()));
+    buf.writeLong(sound.seed().orElse(ThreadLocalRandom.current().nextLong()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
@@ -17,6 +17,7 @@
 
 package com.velocitypowered.proxy.tablist;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import com.velocitypowered.api.proxy.player.ChatSession;
@@ -31,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -39,8 +39,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Exposes the legacy 1.7 tab list to "plugins".
  */
 public class VelocityTabListLegacy extends KeyedVelocityTabList {
-
-  private static final AtomicLong NEXT_LEGACY_ENTRY_ID = new AtomicLong();
 
   private final Map<String, UUID> nameMapping = new ConcurrentHashMap<>();
 
@@ -99,7 +97,7 @@ public class VelocityTabListLegacy extends KeyedVelocityTabList {
             entry.setLatencyInternal(item.getLatency());
           }
         } else {
-          UUID uuid = new UUID(0L, NEXT_LEGACY_ENTRY_ID.incrementAndGet());
+          UUID uuid = UuidCreator.getTimeOrderedEpochFast();
           nameMapping.put(item.getName(), uuid);
           entries.put(uuid, (KeyedVelocityTabListEntry) TabListEntry.builder()
               .tabList(this)

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
@@ -97,6 +97,7 @@ public class VelocityTabListLegacy extends KeyedVelocityTabList {
             entry.setLatencyInternal(item.getLatency());
           }
         } else {
+          // Use a fake UUID to preserve the function of custom entries
           UUID uuid = UuidCreator.getTimeOrderedEpochFast();
           nameMapping.put(item.getName(), uuid);
           entries.put(uuid, (KeyedVelocityTabListEntry) TabListEntry.builder()

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -38,6 +39,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Exposes the legacy 1.7 tab list to "plugins".
  */
 public class VelocityTabListLegacy extends KeyedVelocityTabList {
+
+  private static final AtomicLong NEXT_LEGACY_ENTRY_ID = new AtomicLong();
 
   private final Map<String, UUID> nameMapping = new ConcurrentHashMap<>();
 
@@ -96,7 +99,7 @@ public class VelocityTabListLegacy extends KeyedVelocityTabList {
             entry.setLatencyInternal(item.getLatency());
           }
         } else {
-          UUID uuid = UUID.randomUUID(); // Use a fake uuid to preserve the function of custom entries
+          UUID uuid = new UUID(0L, NEXT_LEGACY_ENTRY_ID.incrementAndGet());
           nameMapping.put(item.getName(), uuid);
           entries.put(uuid, (KeyedVelocityTabListEntry) TabListEntry.builder()
               .tabList(this)


### PR DESCRIPTION
`SecureRandom` introduces locks, which may degrade runtime performance on hot paths. This attempts to more safely and "quickly" provide a near-identical result to the previous SecureRandom's and doesn't appear to have implications with the previous discussion in mind.