### PR TITLE
Preserve unsigned dimension IDs for modded servers (preserve commit author)

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -275,11 +275,17 @@ public class JoinGamePacket implements MinecraftPacket {
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_9_1)) {
       this.dimension = buf.readInt();
     } else {
-      // Read as signed byte, then convert to unsigned for modded dimension IDs > 127
-      // (e.g. dimension 180 would be read as signed byte -76, but should be stored as 180).
-      // Preserve -1 (Nether) as-is since it is the only standard negative dimension ID.
-      int raw = buf.readByte();
-      this.dimension = (raw < -1) ? (raw & 0xFF) : raw;
+      // Vanilla 1.7.10 uses a signed byte for dimension (-1 Nether, 0 Overworld, 1 End).
+      // Modded servers hack this to an unsigned byte to allow dim IDs up to 255.
+      // We must store the canonical int here because RespawnPacket.fromJoinGame copies this
+      // value into a packet that encodes dimension as a 4-byte int (RespawnPacket.encode,
+      // pre-1.16 logic). Sign-extending a modded byte like 0xB4 to int -76 sends an
+      // illegal dimension ID to the client and crashes it.
+      //
+      // The wire byte is ambiguous: 0xFF could be vanilla Nether (-1) or modded dim 255.
+      // We resolve in Nether's favor since vanilla 1.7.10 only ever uses -1/0/1.
+      short raw = buf.readUnsignedByte();
+      this.dimension = raw == 0xFF ? -1 : raw;
     }
 
     if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_13_2)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -275,7 +275,11 @@ public class JoinGamePacket implements MinecraftPacket {
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_9_1)) {
       this.dimension = buf.readInt();
     } else {
-      this.dimension = buf.readByte();
+      // Read as signed byte, then convert to unsigned for modded dimension IDs > 127
+      // (e.g. dimension 180 would be read as signed byte -76, but should be stored as 180).
+      // Preserve -1 (Nether) as-is since it is the only standard negative dimension ID.
+      int raw = buf.readByte();
+      this.dimension = (raw < -1) ? (raw & 0xFF) : raw;
     }
 
     if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_13_2)) {


### PR DESCRIPTION
I don't like this. But it works. RespawnPacket encodes the dimension as an int instead of a byte, which is where the actual bug occurs.

Reading this as an unsigned byte, then just writing it back as a byte in JoinGamePacket is a NOP. When switching servers, due to some weirdness with old clients we need to send a RespawnPacket that's generated off of this JoinGamePacket. That's when we write this previously signed byte as an int, resulting in a different value than the client expects.

This is a huge hack because we still need `-1` to work for the nether. I've added a comment explaining exactly why this is needed for future readers.