### PR TITLE
Rebase closest locale into CTD & use non-deprecated Locale return

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/TranslationRegistryManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/TranslationRegistryManager.java
@@ -19,7 +19,7 @@ package com.velocitypowered.proxy;
 
 import static java.util.function.Function.identity;
 
-import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
+import com.velocitypowered.proxy.util.ClosestLocaleTranslator;
 import com.velocitypowered.proxy.util.ResourceUtils;
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,6 +72,8 @@ public class TranslationRegistryManager {
         MiniMessageTranslationStore.create(this.translationRegistryKey);
     translationRegistry.defaultLocale(Locale.US);
 
+    ClosestLocaleTranslator closestLocaleTranslator = new ClosestLocaleTranslator(translationRegistry);
+
     try {
       ResourceUtils.visitResources(VelocityServer.class, path -> {
         Path langPath = Path.of("lang");
@@ -103,7 +105,7 @@ public class TranslationRegistryManager {
           try (Stream<Path> langFiles = Files.walk(langPath)) {
             langFiles.filter(Files::isRegularFile).forEach(file -> {
               try {
-                registerTranslation(file, translationRegistry);
+                registerTranslation(file, translationRegistry, closestLocaleTranslator);
               } catch (Exception e) {
                 LOGGER.error("Failed registering translations from {}", file, e);
               }
@@ -118,10 +120,11 @@ public class TranslationRegistryManager {
       return;
     }
 
-    GlobalTranslator.translator().addSource(translationRegistry);
+    GlobalTranslator.translator().addSource(closestLocaleTranslator);
   }
 
-  private void registerTranslation(Path file, MiniMessageTranslationStore translationRegistry) throws IOException {
+  private void registerTranslation(Path file, MiniMessageTranslationStore translationRegistry,
+                                   ClosestLocaleTranslator closestLocaleTranslator) throws IOException {
     String localePart = com.google.common.io.Files
         .getNameWithoutExtension(file.getFileName().toString());
     if (localePart.startsWith("messages")) {
@@ -137,7 +140,7 @@ public class TranslationRegistryManager {
         : Locale.forLanguageTag(localePart.replace('_', '-'));
 
     translationRegistry.registerAll(locale, file, false);
-    ClosestLocaleMatcher.INSTANCE.registerKnown(locale);
+    closestLocaleTranslator.registerKnown(locale);
   }
 
   private void saveMissingFile(Path src, Path target) throws IOException {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -57,7 +57,6 @@ import com.velocitypowered.proxy.protocol.netty.PlayPacketQueueInboundHandler;
 import com.velocitypowered.proxy.protocol.netty.PlayPacketQueueOutboundHandler;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.SetCompressionPacket;
-import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
 import com.velocitypowered.proxy.util.except.QuietDecoderException;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -204,8 +203,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
           if (activeSessionHandler instanceof ClientPlaySessionHandler) {
             if (MAX_CLIENT_PACKET_SIZE > 0 && buf.readableBytes() > MAX_CLIENT_PACKET_SIZE) {
               LOGGER.error("{}: received oversized packet ({} bytes > {} byte limit)", association, buf.readableBytes(), MAX_CLIENT_PACKET_SIZE);
-              Component translated = GlobalTranslator.render(Component.translatable("velocity.kick.oversized-packet"),
-                  ClosestLocaleMatcher.INSTANCE.lookupClosest(Locale.getDefault()));
+              Component translated = GlobalTranslator.render(Component.translatable("velocity.kick.oversized-packet"), Locale.getDefault());
               closeWith(DisconnectPacket.create(translated, getProtocolVersion(), getState()));
               return;
             }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -115,7 +115,6 @@ import com.velocitypowered.proxy.tablist.InternalTabList;
 import com.velocitypowered.proxy.tablist.KeyedVelocityTabList;
 import com.velocitypowered.proxy.tablist.VelocityTabList;
 import com.velocitypowered.proxy.tablist.VelocityTabListLegacy;
-import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
 import com.velocitypowered.proxy.util.ComponentUtils;
 import com.velocitypowered.proxy.util.DurationUtils;
 import com.velocitypowered.proxy.util.TranslatableMapper;
@@ -570,7 +569,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       locale = Locale.getDefault();
     }
 
-    locale = ClosestLocaleMatcher.INSTANCE.lookupClosest(locale);
     return GlobalTranslator.render(message, locale);
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
@@ -25,7 +25,6 @@ import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
 import com.velocitypowered.proxy.connection.util.VelocityInboundConnection;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.HandshakePacket;
-import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
 import java.net.InetSocketAddress;
 import java.util.Locale;
 import java.util.Optional;
@@ -101,8 +100,7 @@ public final class InitialInboundConnection implements VelocityInboundConnection
    * @param reason the reason for disconnecting
    */
   public void disconnect(Component reason) {
-    Component translated = GlobalTranslator.render(reason, ClosestLocaleMatcher.INSTANCE
-        .lookupClosest(Locale.getDefault()));
+    Component translated = GlobalTranslator.render(reason, Locale.getDefault());
     if (connection.server.getConfiguration().isLogOfflineConnections()
         && connection.server.getConfiguration().isLogMinimumVersion()) {
 
@@ -120,8 +118,7 @@ public final class InitialInboundConnection implements VelocityInboundConnection
    * @param reason the reason for disconnecting
    */
   public void disconnectQuietly(Component reason) {
-    Component translated = GlobalTranslator.render(reason, ClosestLocaleMatcher.INSTANCE
-        .lookupClosest(Locale.getDefault()));
+    Component translated = GlobalTranslator.render(reason, Locale.getDefault());
     connection.closeWith(DisconnectPacket.create(translated, getProtocolVersion(), connection.getState()));
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -26,7 +26,6 @@ import com.velocitypowered.api.permission.PermissionProvider;
 import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.proxy.VelocityServer;
-import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -80,7 +79,7 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
 
   private static final @NotNull PointersSupplier<VelocityConsole> POINTERS = PointersSupplier.<VelocityConsole>builder()
       .resolving(PermissionChecker.POINTER, VelocityConsole::getPermissionChecker)
-      .resolving(Identity.LOCALE, (console) -> ClosestLocaleMatcher.INSTANCE.lookupClosest(Locale.getDefault()))
+      .resolving(Identity.LOCALE, (console) -> Locale.getDefault())
       .resolving(FacetPointers.TYPE, (console) -> Type.CONSOLE)
       .build();
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ClosestLocaleTranslator.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ClosestLocaleTranslator.java
@@ -19,22 +19,28 @@ package com.velocitypowered.proxy.util;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.translation.Translator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Matches a player's locale to the "closest" Velocity locale, for message localization.
  */
-public final class ClosestLocaleMatcher {
+public class ClosestLocaleTranslator implements Translator {
 
-  public static final ClosestLocaleMatcher INSTANCE = new ClosestLocaleMatcher();
-
+  private final Translator delegate;
   private final Map<String, Locale> byLanguage;
-
   private final LoadingCache<Locale, Locale> closest;
 
-  private ClosestLocaleMatcher() {
+  public ClosestLocaleTranslator(Translator delegate) {
+    this.delegate = delegate;
     this.byLanguage = new ConcurrentHashMap<>();
     this.closest = Caffeine.newBuilder().build(sublocale -> {
       String tag = sublocale.getLanguage();
@@ -48,7 +54,7 @@ public final class ClosestLocaleMatcher {
    * @param locale locale to register
    */
   public void registerKnown(Locale locale) {
-    if (locale.getLanguage().equals(new Locale("zh").getLanguage())) {
+    if (locale.getLanguage().equals(Locale.of("zh").getLanguage())) {
       return;
     }
 
@@ -57,5 +63,26 @@ public final class ClosestLocaleMatcher {
 
   public Locale lookupClosest(Locale locale) {
     return closest.get(locale);
+  }
+
+  @Override
+  public @NotNull Key name() {
+    return delegate.name();
+  }
+
+  @Override
+  public boolean canTranslate(@NotNull String key, @NotNull Locale locale) {
+    return delegate.canTranslate(key, lookupClosest(locale));
+  }
+
+  @Override
+  public @Nullable MessageFormat translate(@NotNull String key, @NotNull Locale locale) {
+    return delegate.translate(key, lookupClosest(locale));
+  }
+
+  @Override
+  public @Nullable Component translate(@NotNull TranslatableComponent component,
+                                       @NotNull Locale locale) {
+    return delegate.translate(component, lookupClosest(locale));
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ClosestLocaleTranslator.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ClosestLocaleTranslator.java
@@ -61,10 +61,6 @@ public class ClosestLocaleTranslator implements Translator {
     this.byLanguage.put(locale.getLanguage(), locale);
   }
 
-  public Locale lookupClosest(Locale locale) {
-    return closest.get(locale);
-  }
-
   @Override
   public @NotNull Key name() {
     return delegate.name();
@@ -84,5 +80,9 @@ public class ClosestLocaleTranslator implements Translator {
   public @Nullable Component translate(@NotNull TranslatableComponent component,
                                        @NotNull Locale locale) {
     return delegate.translate(component, lookupClosest(locale));
+  }
+
+  private Locale lookupClosest(Locale locale) {
+    return closest.get(locale);
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
@@ -48,7 +48,7 @@ public enum TranslatableMapper implements BiConsumer<TranslatableComponent, Cons
   @Override
   public void accept(TranslatableComponent translatableComponent,
                      Consumer<Component> componentConsumer) {
-    Locale locale = ClosestLocaleMatcher.INSTANCE.lookupClosest(Locale.getDefault());
+    Locale locale = Locale.getDefault();
     if (GlobalTranslator.translator().canTranslate(translatableComponent.key(), locale)) {
       componentConsumer.accept(GlobalTranslator.render(translatableComponent, locale));
     } else {


### PR DESCRIPTION
This implementation appears stable and has been approved twice; the only real difference is that it covers additional CTD implementations and strips the deprecated `new Locale` in favor of `Locale.of`.