### PR TITLE
Implement rebase of https://github.com/PaperMC/Velocity/pull/1495 with comments addressed

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/redis/provider/LettuceProvider.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/provider/LettuceProvider.java
@@ -391,6 +391,23 @@ public final class LettuceProvider extends AbstractRedisProvider {
   }
 
   /**
+   * Atomically sets the key only if it does not already exist using the regular (non-pub/sub)
+   * connection.
+   *
+   * @param key   the key to set
+   * @param value the value to store
+   */
+  @Override
+  public void setIfAbsent(@NotNull String key, @NotNull String value) {
+    if (this.syncPublisher == null) {
+      LOGGER.warn("Attempted to set-if-absent key '{}' but the sync connection is not initialized", key);
+      return;
+    }
+
+    this.syncPublisher.setnx(key, value);
+  }
+
+  /**
    * Checks whether a key exists in Redis using the regular (non-pub/sub) connection.
    *
    * @param key the key to check

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/provider/RedisProvider.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/provider/RedisProvider.java
@@ -141,6 +141,14 @@ public sealed interface RedisProvider permits AbstractRedisProvider {
   void setWithExpiry(@NotNull String key, @NotNull String value, long ttlSeconds);
 
   /**
+   * Atomically sets the key to the given value only if it does not already exist.
+   *
+   * @param key   the key to set
+   * @param value the value to store
+   */
+  void setIfAbsent(@NotNull String key, @NotNull String value);
+
+  /**
    * Checks whether a key exists in Redis.
    *
    * @param key the key to check

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -76,6 +76,7 @@ import com.velocitypowered.proxy.config.ProxyAddress;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.client.PlayerRegistry;
+import com.velocitypowered.proxy.connection.player.resourcepack.TransferPackSecret;
 import com.velocitypowered.proxy.connection.player.resourcepack.VelocityResourcePackInfo;
 import com.velocitypowered.proxy.connection.util.ServerListPingHandler;
 import com.velocitypowered.proxy.console.VelocityConsole;
@@ -258,6 +259,12 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
    */
   private @MonotonicNonNull VelocityClusterProxyService clusterProxyService;
 
+  /**
+   * The HMAC secret used to sign and verify the applied-resource-packs transfer cookie.
+   * Initialized after Redis (or generated locally when Redis is disabled).
+   */
+  private @MonotonicNonNull TransferPackSecret transferPackSecret;
+
   VelocityServer(ProxyOptions options) {
     pluginManager = new VelocityPluginManager(this);
     eventManager = new VelocityEventManager(pluginManager);
@@ -297,6 +304,16 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
    */
   public VelocityRedis getRedis() {
     return redis;
+  }
+
+  /**
+   * Returns the {@link TransferPackSecret} used to sign and verify the
+   * applied-resource-packs cookie carried across {@code transferToHost}.
+   *
+   * @return the transfer-pack secret holder
+   */
+  public TransferPackSecret getTransferPackSecret() {
+    return transferPackSecret;
   }
 
   @Override
@@ -419,6 +436,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
         queueManager = new VelocityQueueManager(this);
       }
     }
+
+    transferPackSecret = new TransferPackSecret(redis);
 
     registerCommands();
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -26,6 +26,7 @@ import com.velocitypowered.api.event.permission.PermissionsSetupEvent;
 import com.velocitypowered.api.event.player.CookieReceiveEvent;
 import com.velocitypowered.api.event.player.GameProfileRequestEvent;
 import com.velocitypowered.api.event.player.PlayerChooseInitialServerEvent;
+import com.velocitypowered.api.network.HandshakeIntent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
@@ -36,6 +37,7 @@ import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackTransfer;
 import com.velocitypowered.proxy.crypto.IdentifiedKeyImpl;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.LoginAcknowledgedPacket;
@@ -44,6 +46,8 @@ import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket
 import com.velocitypowered.proxy.protocol.packet.SetCompressionPacket;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.CodecException;
+import java.security.SignatureException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -85,6 +89,8 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
 
   private final String serverIdHash;
 
+  private final CompletableFuture<byte[]> appliedResourcePacksFuture;
+
   /**
    * The minimum Minecraft version allowed to connect.
    */
@@ -96,13 +102,15 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
   private final String maximumVersion;
 
   AuthSessionHandler(VelocityServer server, LoginInboundConnection inbound,
-                     GameProfile profile, boolean onlineMode, String serverIdHash) {
+                     GameProfile profile, boolean onlineMode, String serverIdHash,
+                     CompletableFuture<byte[]> appliedResourcePacksFuture) {
     this.server = Preconditions.checkNotNull(server, "server");
     this.inbound = Preconditions.checkNotNull(inbound, "inbound");
     this.profile = Preconditions.checkNotNull(profile, "profile");
     this.onlineMode = onlineMode;
     this.mcConnection = inbound.delegatedConnection();
     this.serverIdHash = serverIdHash;
+    this.appliedResourcePacksFuture = appliedResourcePacksFuture;
     this.minimumVersion = server.getConfiguration().getMinimumVersion();
     this.maximumVersion = server.getConfiguration().getMaximumVersion()
         .orElse(ProtocolVersion.MAXIMUM_VERSION.getMostRecentSupportedVersion());
@@ -165,7 +173,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
 
         return server.getEventManager()
             .fire(new PermissionsSetupEvent(player, ConnectedPlayer.DEFAULT_PERMISSIONS))
-            .thenAcceptAsync(event -> {
+            .thenAcceptBothAsync(appliedResourcePacksFuture, (event, appliedResourcePacksCookie) -> {
               if (!mcConnection.isClosed()) {
                 // wait for permissions to load, then set the players permission function
                 PermissionFunction function = event.createFunction(player);
@@ -177,6 +185,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
                 } else {
                   player.setPermissionFunction(function);
                 }
+                loadAppliedResourcePacks(player, appliedResourcePacksCookie);
                 startLoginCompletion(player);
               }
             }, mcConnection.eventLoop());
@@ -185,6 +194,22 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
       LOGGER.error("Exception during connection of {}", finalProfile, ex);
       return null;
     });
+  }
+
+  private void loadAppliedResourcePacks(ConnectedPlayer player, byte[] cookieData) {
+    if (player.getHandshakeIntent() != HandshakeIntent.TRANSFER || cookieData == null) {
+      return;
+    }
+
+    try {
+      ResourcePackTransfer.TransferSession session = ResourcePackTransfer.decodeAndValidateCookieData(
+          server.getConfiguration().getForwardingSecret(), cookieData);
+      player.resourcePackHandler().loadAppliedResourcePacks(session.appliedPacks());
+    } catch (SignatureException e) {
+      LOGGER.warn("Signature error while loading applied resource packs of {}", player.getUsername(), e);
+    } catch (IndexOutOfBoundsException | CodecException e) {
+      LOGGER.warn("Error while decoding applied resource packs of {}", player.getUsername(), e);
+    }
   }
 
   private boolean versionCheck(MinecraftConnection connection) {
@@ -270,6 +295,11 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(ServerboundCookieResponsePacket packet) {
+    if (packet.getKey().equals(ResourcePackTransfer.APPLIED_RESOURCE_PACKS_KEY)) {
+      appliedResourcePacksFuture.complete(packet.getPayload());
+      return true;
+    }
+
     server.getEventManager()
         .fire(new CookieReceiveEvent(connectedPlayer, packet.getKey(), packet.getPayload()))
         .thenAcceptAsync(event -> {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -46,7 +46,6 @@ import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket
 import com.velocitypowered.proxy.protocol.packet.SetCompressionPacket;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.CodecException;
 import java.security.SignatureException;
 import java.util.Objects;
 import java.util.Optional;
@@ -207,7 +206,8 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
       player.resourcePackHandler().loadAppliedResourcePacks(session.appliedPacks());
     } catch (SignatureException e) {
       LOGGER.warn("Signature error while loading applied resource packs of {}", player.getUsername(), e);
-    } catch (IndexOutOfBoundsException | CodecException e) {
+    } catch (RuntimeException e) {
+      // Restoring pack state is best-effort; don't let exceptions bubble up and skip login completion.
       LOGGER.warn("Error while decoding applied resource packs of {}", player.getUsername(), e);
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -203,7 +203,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
 
     try {
       ResourcePackTransfer.TransferSession session = ResourcePackTransfer.decodeAndValidateCookieData(
-          server.getConfiguration().getForwardingSecret(), cookieData);
+          server.getTransferPackSecret().get(), cookieData);
       player.resourcePackHandler().loadAppliedResourcePacks(session.appliedPacks());
     } catch (SignatureException e) {
       LOGGER.warn("Signature error while loading applied resource packs of {}", player.getUsername(), e);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1591,10 +1591,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     ResourcePackTransfer.TransferSession session = new ResourcePackTransfer.TransferSession(
         resourcePackHandler.getAppliedResourcePacks());
     byte[] cookieData = ResourcePackTransfer.createCookieData(
-        server.getConfiguration().getForwardingSecret(), session);
+        server.getTransferPackSecret().get(), session);
     if (cookieData == null) {
-      // No packs to carry across the transfer, or no forwarding secret to sign with. Either
-      // way, the cookie packet would be meaningless.
+      // No packs to carry across the transfer; the cookie packet would be meaningless.
       return;
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1612,6 +1612,12 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
         resourcePackHandler.getAppliedResourcePacks());
     byte[] cookieData = ResourcePackTransfer.createCookieData(
         server.getConfiguration().getForwardingSecret(), session);
+    if (cookieData == null) {
+      // No packs to carry across the transfer, or no forwarding secret to sign with. Either
+      // way, the cookie packet would be meaningless.
+      return;
+    }
+
     connection.write(new ClientboundStoreCookiePacket(
         ResourcePackTransfer.APPLIED_RESOURCE_PACKS_KEY, cookieData));
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1592,13 +1592,14 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
         resourcePackHandler.getAppliedResourcePacks());
     byte[] cookieData = ResourcePackTransfer.createCookieData(
         server.getTransferPackSecret().get(), session);
-    if (cookieData == null) {
-      // No packs to carry across the transfer; the cookie packet would be meaningless.
-      return;
-    }
 
+    // When there are no packs to carry we still store an empty payload. Cookies persist on the
+    // client across transfers, so skipping the write would leave a cookie a previous proxy stored
+    // intact, and a later hop would then read stale applied-pack state. The receiving side decodes
+    // an empty payload as "no applied packs".
     connection.write(new ClientboundStoreCookiePacket(
-        ResourcePackTransfer.APPLIED_RESOURCE_PACKS_KEY, cookieData));
+        ResourcePackTransfer.APPLIED_RESOURCE_PACKS_KEY,
+        cookieData == null ? new byte[0] : cookieData));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -77,6 +77,7 @@ import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.player.bossbar.BossBarManager;
 import com.velocitypowered.proxy.connection.player.bundle.BundleDelimiterHandler;
+import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackTransfer;
 import com.velocitypowered.proxy.connection.player.resourcepack.VelocityResourcePackInfo;
 import com.velocitypowered.proxy.connection.player.resourcepack.handler.ResourcePackHandler;
 import com.velocitypowered.proxy.connection.util.ConnectionMessages;
@@ -1596,9 +1597,23 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           resultedAddress = address;
         }
 
+        storeAppliedPacks();
         connection.write(new TransferPacket(resultedAddress.getHostName(), resultedAddress.getPort()));
       }
     });
+  }
+
+  private void storeAppliedPacks() {
+    if (connection.getState() != StateRegistry.PLAY && connection.getState() != StateRegistry.CONFIG) {
+      return;
+    }
+
+    ResourcePackTransfer.TransferSession session = new ResourcePackTransfer.TransferSession(
+        resourcePackHandler.getAppliedResourcePacks());
+    byte[] cookieData = ResourcePackTransfer.createCookieData(
+        server.getConfiguration().getForwardingSecret(), session);
+    connection.write(new ClientboundStoreCookiePacket(
+        ResourcePackTransfer.APPLIED_RESOURCE_PACKS_KEY, cookieData));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -27,19 +27,23 @@ import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
 import com.velocitypowered.api.event.connection.PreLoginEvent;
 import com.velocitypowered.api.event.connection.PreLoginEvent.PreLoginComponentResult;
+import com.velocitypowered.api.network.HandshakeIntent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackTransfer;
 import com.velocitypowered.proxy.crypto.IdentifiedKeyImpl;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
+import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.EncryptionRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.EncryptionResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.LoginPluginResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.ServerLoginPacket;
+import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.util.VelocityProperties;
 import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
@@ -48,7 +52,9 @@ import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
@@ -83,6 +89,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
   private final boolean forceKeyAuthentication;
 
+  private CompletableFuture<byte[]> appliedResourcePacksFuture;
+
   InitialLoginSessionHandler(VelocityServer server, MinecraftConnection mcConnection,
                              LoginInboundConnection inbound) {
     this.server = Preconditions.checkNotNull(server, "server");
@@ -90,6 +98,16 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
     this.inbound = Preconditions.checkNotNull(inbound, "inbound");
     this.forceKeyAuthentication = VelocityProperties.readBoolean(
         "auth.forceSecureProfiles", server.getConfiguration().isForceKeyAuthentication());
+  }
+
+  @Override
+  public void activated() {
+    if (inbound.getHandshakeIntent() == HandshakeIntent.TRANSFER) {
+      appliedResourcePacksFuture = new CompletableFuture<byte[]>().completeOnTimeout(null, 20, TimeUnit.SECONDS);
+      mcConnection.write(new ClientboundCookieRequestPacket(ResourcePackTransfer.APPLIED_RESOURCE_PACKS_KEY));
+    } else {
+      appliedResourcePacksFuture = CompletableFuture.completedFuture(null);
+    }
   }
 
   @Override
@@ -158,7 +176,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
           } else {
             mcConnection.setActiveSessionHandler(StateRegistry.LOGIN,
                 new AuthSessionHandler(server, inbound,
-                    GameProfile.forOfflinePlayer(login.getUsername()), false, null));
+                    GameProfile.forOfflinePlayer(login.getUsername()), false, null, appliedResourcePacksFuture));
           }
         });
       });
@@ -246,7 +264,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
                 }
               }
               // All went well, initialize the session.
-              mcConnection.setActiveSessionHandler(StateRegistry.LOGIN, new AuthSessionHandler(server, inbound, profile, true, serverId));
+              mcConnection.setActiveSessionHandler(StateRegistry.LOGIN,
+                  new AuthSessionHandler(server, inbound, profile, true, serverId, appliedResourcePacksFuture));
             } else if (response.getCode() == 204) {
               // Apparently, an offline-mode user logged onto this online-mode proxy.
               inbound.disconnect(
@@ -265,6 +284,16 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
     }
 
     return true;
+  }
+
+  @Override
+  public boolean handle(ServerboundCookieResponsePacket packet) {
+    if (packet.getKey().equals(ResourcePackTransfer.APPLIED_RESOURCE_PACKS_KEY)) {
+      appliedResourcePacksFuture.complete(packet.getPayload());
+      return true;
+    }
+
+    return false;
   }
 
   private EncryptionRequestPacket generateEncryptionRequest() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -50,10 +50,10 @@ import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -69,6 +69,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
   private static final Logger LOGGER = LogManager.getLogger(InitialLoginSessionHandler.class);
+
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   private static final String MOJANG_HASJOINED_URL =
       System.getProperty("mojang.sessionserver",
@@ -298,7 +300,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
   private EncryptionRequestPacket generateEncryptionRequest() {
     byte[] verify = new byte[4];
-    ThreadLocalRandom.current().nextBytes(verify);
+    SECURE_RANDOM.nextBytes(verify);
 
     EncryptionRequestPacket request = new EncryptionRequestPacket();
     request.setPublicKey(server.getServerKeyPair().getPublic().getEncoded());

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
@@ -165,8 +165,8 @@ public final class ResourcePackTransfer {
     ByteBuf buffer = Unpooled.wrappedBuffer(data);
     try {
       int size = ProtocolUtils.readVarInt(buffer);
-      NettyPreconditions.checkFrame(size <= MAX_APPLIED_PACKS,
-          "Too many applied packs (got %s, maximum is %s)", size, MAX_APPLIED_PACKS);
+      NettyPreconditions.checkFrame(size >= 0 && size <= MAX_APPLIED_PACKS,
+          "Invalid applied pack count (got %s, maximum is %s)", size, MAX_APPLIED_PACKS);
       List<ResourcePackInfo> appliedResourcePacks = new ArrayList<>(size);
       for (int i = 0; i < size; i++) {
         VelocityResourcePackInfo.BuilderImpl builder =

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.player.resourcepack;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.api.proxy.player.ResourcePackInfo;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import com.velocitypowered.proxy.protocol.util.NettyPreconditions;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.DecoderException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Utility for serializing and deserializing the signed cookie data that carries applied
+ * resource pack state across a {@code transferToHost} hand-off.
+ */
+public final class ResourcePackTransfer {
+
+  public static final Key APPLIED_RESOURCE_PACKS_KEY = Key.key("velocity", "applied_resource_packs");
+
+  private static final String ALGORITHM = "HmacSHA256";
+  private static final ResourcePackInfo.Origin[] ORIGINS = ResourcePackInfo.Origin.values();
+  private static final int SIGNATURE_LENGTH = 32;
+  private static final int MAX_APPLIED_PACKS = 256;
+
+  private ResourcePackTransfer() {
+    throw new AssertionError();
+  }
+
+  /**
+   * Cookie payload carrying state preserved across a {@code transferToHost}.
+   *
+   * @param appliedPacks the resource packs the player had applied at the moment of transfer
+   */
+  public record TransferSession(Collection<ResourcePackInfo> appliedPacks) {
+  }
+
+  /**
+   * Serializes {@code session} into a signed byte array suitable for sending as a
+   * {@link Key#key(String, String) velocity:applied_resource_packs} cookie. Returns an empty
+   * array when the session has no applied packs.
+   *
+   * @param secret  the proxy's forwarding secret, used as the HMAC key
+   * @param session the transfer-session state to encode
+   * @return signed cookie payload, or an empty array if there is nothing to encode
+   */
+  public static byte[] createCookieData(byte[] secret, TransferSession session) {
+    Collection<ResourcePackInfo> appliedResourcePacks = session.appliedPacks();
+    if (appliedResourcePacks.isEmpty()) {
+      return new byte[0];
+    }
+
+    ByteBuf buffer = Unpooled.buffer(appliedResourcePacks.size() * 256);
+    try {
+      ProtocolUtils.writeVarInt(buffer, appliedResourcePacks.size());
+
+      for (ResourcePackInfo appliedResourcePack : appliedResourcePacks) {
+        ProtocolUtils.writeString(buffer, appliedResourcePack.getUrl());
+        ProtocolUtils.writeUuid(buffer, appliedResourcePack.getId());
+
+        byte[] hash = appliedResourcePack.getHash();
+        buffer.writeBoolean(hash != null);
+        if (hash != null) {
+          Preconditions.checkArgument(hash.length == 20, "Hash length is not 20");
+          buffer.writeBytes(hash);
+        }
+
+        buffer.writeBoolean(appliedResourcePack.getShouldForce());
+        Component prompt = appliedResourcePack.getPrompt();
+        buffer.writeBoolean(prompt != null);
+        if (prompt != null) {
+          ProtocolUtils.writeString(buffer,
+              ProtocolUtils.getJsonChatSerializer(ProtocolVersion.MAXIMUM_VERSION).serialize(prompt));
+        }
+
+        ProtocolUtils.writeVarInt(buffer, appliedResourcePack.getOrigin().ordinal());
+        ProtocolUtils.writeVarInt(buffer, appliedResourcePack.getOriginalOrigin().ordinal());
+      }
+
+      Mac mac = Mac.getInstance(ALGORITHM);
+      mac.init(new SecretKeySpec(secret, ALGORITHM));
+      mac.update(buffer.array(), buffer.arrayOffset(), buffer.readableBytes());
+      buffer.writeBytes(mac.doFinal());
+
+      return Arrays.copyOfRange(buffer.array(), buffer.arrayOffset(),
+          buffer.arrayOffset() + buffer.readableBytes());
+    } catch (InvalidKeyException e) {
+      throw new RuntimeException("Unable to sign applied resource packs cookie data", e);
+    } catch (NoSuchAlgorithmException e) {
+      // Should never happen — HmacSHA256 is mandated by the JDK.
+      throw new AssertionError(e);
+    } finally {
+      buffer.release();
+    }
+  }
+
+  /**
+   * Verifies the HMAC signature on {@code data} and decodes the payload into a
+   * {@link TransferSession}. Returns a session with an empty applied-packs collection when
+   * {@code data} is {@code null} or empty (i.e. the previous proxy had no packs to carry).
+   *
+   * @param secret the proxy's forwarding secret, used to verify the HMAC
+   * @param data   the signed cookie payload, or {@code null}/empty if no cookie was supplied
+   * @return decoded transfer session
+   * @throws SignatureException if the payload is shorter than the signature, the signature
+   *                            does not match the body, or the secret key cannot be used
+   * @throws DecoderException   if the payload is structurally malformed
+   */
+  public static TransferSession decodeAndValidateCookieData(byte[] secret, byte[] data)
+      throws SignatureException, DecoderException {
+    if (data == null || data.length == 0) {
+      return new TransferSession(Collections.emptyList());
+    }
+    if (data.length <= SIGNATURE_LENGTH) {
+      throw new SignatureException("Applied resource packs cookie data has no or incomplete signature");
+    }
+
+    try {
+      Mac mac = Mac.getInstance(ALGORITHM);
+      mac.init(new SecretKeySpec(secret, ALGORITHM));
+      mac.update(data, 0, data.length - SIGNATURE_LENGTH);
+
+      if (!Arrays.equals(mac.doFinal(), 0, SIGNATURE_LENGTH,
+          data, data.length - SIGNATURE_LENGTH, data.length)) {
+        throw new SignatureException("Applied resource packs cookie data has invalid signature");
+      }
+    } catch (InvalidKeyException e) {
+      throw new RuntimeException("Unable to verify signature of applied resource packs cookie data", e);
+    } catch (NoSuchAlgorithmException e) {
+      // Should never happen — HmacSHA256 is mandated by the JDK.
+      throw new AssertionError(e);
+    }
+
+    ByteBuf buffer = Unpooled.wrappedBuffer(data);
+    try {
+      int size = ProtocolUtils.readVarInt(buffer);
+      NettyPreconditions.checkFrame(size <= MAX_APPLIED_PACKS,
+          "Too many applied packs (got %s, maximum is %s)", size, MAX_APPLIED_PACKS);
+      List<ResourcePackInfo> appliedResourcePacks = new ArrayList<>(size);
+      for (int i = 0; i < size; i++) {
+        VelocityResourcePackInfo.BuilderImpl builder =
+            new VelocityResourcePackInfo.BuilderImpl(ProtocolUtils.readString(buffer));
+        builder.setId(ProtocolUtils.readUuid(buffer));
+        if (buffer.readBoolean()) {
+          byte[] hash = new byte[20];
+          buffer.readBytes(hash);
+          builder.setHash(hash);
+        }
+
+        builder.setShouldForce(buffer.readBoolean());
+        if (buffer.readBoolean()) {
+          builder.setPrompt(ProtocolUtils.getJsonChatSerializer(ProtocolVersion.MAXIMUM_VERSION)
+              .deserialize(ProtocolUtils.readString(buffer)));
+        }
+
+        builder.setOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
+        VelocityResourcePackInfo appliedResourcePack = (VelocityResourcePackInfo) builder.build();
+        appliedResourcePack.setOriginalOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
+        appliedResourcePacks.add(appliedResourcePack);
+      }
+      return new TransferSession(appliedResourcePacks);
+    } finally {
+      buffer.release();
+    }
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
@@ -37,6 +37,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility for serializing and deserializing the signed cookie data that carries applied
@@ -65,17 +66,23 @@ public final class ResourcePackTransfer {
 
   /**
    * Serializes {@code session} into a signed byte array suitable for sending as a
-   * {@link Key#key(String, String) velocity:applied_resource_packs} cookie. Returns an empty
-   * array when the session has no applied packs.
+   * {@link Key#key(String, String) velocity:applied_resource_packs} cookie. Returns
+   * {@code null} when the cookie should not be sent at all, specifically when the session
+   * has no applied packs, or when {@code secret} is empty (no forwarding secret is configured,
+   * which prevents signing and disables transfer-pack restoration entirely).
    *
    * @param secret  the proxy's forwarding secret, used as the HMAC key
    * @param session the transfer-session state to encode
-   * @return signed cookie payload, or an empty array if there is nothing to encode
+   * @return signed cookie payload, or {@code null} if no cookie should be sent
    */
-  public static byte[] createCookieData(byte[] secret, TransferSession session) {
+  public static byte @Nullable [] createCookieData(byte[] secret, TransferSession session) {
     Collection<ResourcePackInfo> appliedResourcePacks = session.appliedPacks();
     if (appliedResourcePacks.isEmpty()) {
-      return new byte[0];
+      return null;
+    }
+
+    if (secret.length == 0) {
+      return null;
     }
 
     ByteBuf buffer = Unpooled.buffer(appliedResourcePacks.size() * 256);
@@ -136,9 +143,10 @@ public final class ResourcePackTransfer {
    */
   public static TransferSession decodeAndValidateCookieData(byte[] secret, byte[] data)
       throws SignatureException, DecoderException {
-    if (data == null || data.length == 0) {
+    if (data == null || data.length == 0 || secret.length == 0) {
       return new TransferSession(Collections.emptyList());
     }
+
     if (data.length <= SIGNATURE_LENGTH) {
       throw new SignatureException("Applied resource packs cookie data has no or incomplete signature");
     }
@@ -186,6 +194,7 @@ public final class ResourcePackTransfer {
         appliedResourcePack.setOriginalOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
         appliedResourcePacks.add(appliedResourcePack);
       }
+
       return new TransferSession(appliedResourcePacks);
     } finally {
       buffer.release();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
@@ -182,7 +182,7 @@ public final class ResourcePackTransfer {
         }
 
         builder.setOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
-        VelocityResourcePackInfo appliedResourcePack = (VelocityResourcePackInfo) builder.build();
+        VelocityResourcePackInfo appliedResourcePack = builder.build();
         appliedResourcePack.setOriginalOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
         appliedResourcePacks.add(appliedResourcePack);
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
@@ -67,21 +67,16 @@ public final class ResourcePackTransfer {
   /**
    * Serializes {@code session} into a signed byte array suitable for sending as a
    * {@link Key#key(String, String) velocity:applied_resource_packs} cookie. Returns
-   * {@code null} when the cookie should not be sent at all, specifically when the session
-   * has no applied packs, or when {@code secret} is empty (no forwarding secret is configured,
-   * which prevents signing and disables transfer-pack restoration entirely).
+   * {@code null} when the session has no applied packs, in which case there is nothing
+   * worth carrying across the transfer.
    *
-   * @param secret  the proxy's forwarding secret, used as the HMAC key
+   * @param secret  the HMAC key used to sign the payload (see {@link TransferPackSecret})
    * @param session the transfer-session state to encode
    * @return signed cookie payload, or {@code null} if no cookie should be sent
    */
   public static byte @Nullable [] createCookieData(byte[] secret, TransferSession session) {
     Collection<ResourcePackInfo> appliedResourcePacks = session.appliedPacks();
     if (appliedResourcePacks.isEmpty()) {
-      return null;
-    }
-
-    if (secret.length == 0) {
       return null;
     }
 
@@ -134,7 +129,7 @@ public final class ResourcePackTransfer {
    * {@link TransferSession}. Returns a session with an empty applied-packs collection when
    * {@code data} is {@code null} or empty (i.e. the previous proxy had no packs to carry).
    *
-   * @param secret the proxy's forwarding secret, used to verify the HMAC
+   * @param secret the HMAC key used to verify the payload (see {@link TransferPackSecret})
    * @param data   the signed cookie payload, or {@code null}/empty if no cookie was supplied
    * @return decoded transfer session
    * @throws SignatureException if the payload is shorter than the signature, the signature
@@ -143,7 +138,7 @@ public final class ResourcePackTransfer {
    */
   public static TransferSession decodeAndValidateCookieData(byte[] secret, byte[] data)
       throws SignatureException, DecoderException {
-    if (data == null || data.length == 0 || secret.length == 0) {
+    if (data == null || data.length == 0) {
       return new TransferSession(Collections.emptyList());
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/TransferPackSecret.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/TransferPackSecret.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.player.resourcepack;
+
+import com.velocityctd.proxy.redis.VelocityRedis;
+import com.velocityctd.proxy.redis.provider.RedisProvider;
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Owns the HMAC key used to sign and verify the
+ * {@link ResourcePackTransfer#APPLIED_RESOURCE_PACKS_KEY applied_resource_packs} cookie carried
+ * across a {@code transferToHost} hand-off.
+ */
+public final class TransferPackSecret {
+
+  private static final Logger LOGGER = LogManager.getLogger(TransferPackSecret.class);
+  private static final String REDIS_KEY_SUFFIX = ":transfer-pack-secret";
+
+  /**
+   * Length of the HMAC key in bytes (256 bits).
+   */
+  private static final int SECRET_LENGTH = 32;
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final byte[] secret;
+
+  /**
+   * Initializes the transfer-pack secret, fetching it from Redis when available or generating
+   * a per-JVM secret otherwise.
+   *
+   * @param redis the Redis module, or {@code null} when Redis is not enabled
+   */
+  public TransferPackSecret(@Nullable VelocityRedis redis) {
+    if (redis != null && redis.getProvider().isConnected()) {
+      this.secret = initFromRedis(redis);
+    } else {
+      this.secret = generate();
+      LOGGER.info("Transfer-pack secret generated locally (Redis not in use); cookies cannot "
+          + "be verified by other proxies or after a restart");
+    }
+  }
+
+  /**
+   * Returns the raw secret bytes used to sign and verify transfer-pack cookies.
+   *
+   * @return the secret
+   */
+  public byte @NotNull [] get() {
+    return secret;
+  }
+
+  private static byte[] initFromRedis(VelocityRedis redis) {
+    RedisProvider provider = redis.getProvider();
+    String key = provider.getNamespace() + REDIS_KEY_SUFFIX;
+
+    String candidate = Base64.getEncoder().encodeToString(generate());
+    provider.setIfAbsent(key, candidate);
+
+    String stored = provider.get(key);
+    if (stored == null) {
+      LOGGER.warn("Transfer-pack secret missing from Redis right after SETNX; using a "
+          + "locally generated value for this JVM");
+      return Base64.getDecoder().decode(candidate);
+    }
+    return Base64.getDecoder().decode(stored);
+  }
+
+  private static byte[] generate() {
+    byte[] secret = new byte[SECRET_LENGTH];
+    RANDOM.nextBytes(secret);
+    return secret;
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/VelocityResourcePackInfo.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/VelocityResourcePackInfo.java
@@ -197,7 +197,7 @@ public final class VelocityResourcePackInfo implements ResourcePackInfo {
     }
 
     @Override
-    public ResourcePackInfo build() {
+    public VelocityResourcePackInfo build() {
       return new VelocityResourcePackInfo(id, url, hash, shouldForce, prompt, origin);
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/LegacyResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/LegacyResourcePackHandler.java
@@ -70,6 +70,12 @@ public sealed class LegacyResourcePackHandler extends ResourcePackHandler permit
   }
 
   @Override
+  public void loadAppliedResourcePacks(Collection<ResourcePackInfo> appliedResourcePacks) {
+    throw new UnsupportedOperationException(
+        "Legacy resource pack handlers do not support loading applied packs from a transfer");
+  }
+
+  @Override
   public @NotNull Collection<ResourcePackInfo> getPendingResourcePacks() {
     if (pendingResourcePack == null) {
       return List.of();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ModernResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ModernResourcePackHandler.java
@@ -76,6 +76,14 @@ public final class ModernResourcePackHandler extends ResourcePackHandler {
   }
 
   @Override
+  public void loadAppliedResourcePacks(Collection<ResourcePackInfo> appliedResourcePacks) {
+    this.appliedResourcePacks.clear();
+    for (ResourcePackInfo appliedResourcePack : appliedResourcePacks) {
+      this.appliedResourcePacks.put(appliedResourcePack.getId(), appliedResourcePack);
+    }
+  }
+
+  @Override
   public @NotNull Collection<ResourcePackInfo> getPendingResourcePacks() {
     return List.copyOf(pendingResourcePacks.values());
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ResourcePackHandler.java
@@ -81,6 +81,8 @@ public abstract sealed class ResourcePackHandler permits LegacyResourcePackHandl
 
   public abstract @NotNull Collection<ResourcePackInfo> getAppliedResourcePacks();
 
+  public abstract void loadAppliedResourcePacks(Collection<ResourcePackInfo> appliedResourcePacks);
+
   public abstract @NotNull Collection<ResourcePackInfo> getPendingResourcePacks();
 
   /**


### PR DESCRIPTION
CTD makes great use of this feature, since we inherently support multiple proxies with our Redis platform. Refactoring this until completion is idealistic for users moving players around. If networks supply their resourcepacks via proxy, manual resends and actual user reconnects are more favorable (i.e., FreshSMP).