### PR TITLE
Validate resource-pack origin ordinals before array indexing

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackTransfer.java
@@ -184,9 +184,9 @@ public final class ResourcePackTransfer {
               .deserialize(ProtocolUtils.readString(buffer)));
         }
 
-        builder.setOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
+        builder.setOrigin(readOrigin(buffer));
         VelocityResourcePackInfo appliedResourcePack = builder.build();
-        appliedResourcePack.setOriginalOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
+        appliedResourcePack.setOriginalOrigin(readOrigin(buffer));
         appliedResourcePacks.add(appliedResourcePack);
       }
 
@@ -194,5 +194,12 @@ public final class ResourcePackTransfer {
     } finally {
       buffer.release();
     }
+  }
+
+  private static ResourcePackInfo.Origin readOrigin(ByteBuf buffer) {
+    int ordinal = ProtocolUtils.readVarInt(buffer);
+    NettyPreconditions.checkFrame(ordinal >= 0 && ordinal < ORIGINS.length,
+        "Invalid resource pack origin ordinal (got %s, maximum is %s)", ordinal, ORIGINS.length - 1);
+    return ORIGINS[ordinal];
   }
 }


### PR DESCRIPTION
## Summary

`ResourcePackTransfer.decodeAndValidateCookieData` indexed the `Origin` enum array directly with a value read from the cookie payload:

```java
builder.setOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
...
appliedResourcePack.setOriginalOrigin(ORIGINS[ProtocolUtils.readVarInt(buffer)]);
```

A negative or out-of-range ordinal therefore throws `ArrayIndexOutOfBoundsException` mid-decode. While the payload is HMAC-verified (so this is not directly attacker-forgeable), a version/enum mismatch across a cluster — where one proxy writes an ordinal the receiving proxy's enum no longer has — would crash the decode instead of failing gracefully.

## Change

Both reads now go through a `readOrigin` helper that validates the ordinal with `NettyPreconditions.checkFrame` before indexing, degrading to a graceful frame error. This mirrors the existing applied-pack-count bounds check a few lines above.

```java
private static ResourcePackInfo.Origin readOrigin(ByteBuf buffer) {
  int ordinal = ProtocolUtils.readVarInt(buffer);
  NettyPreconditions.checkFrame(ordinal >= 0 && ordinal < ORIGINS.length,
      "Invalid resource pack origin ordinal (got %s, maximum is %s)", ordinal, ORIGINS.length - 1);
  return ORIGINS[ordinal];
}
```

## Notes

A separate, related hardening fix (constant-time HMAC comparison for the same cookie) lives on its own branch and is intentionally kept out of this PR.

https://claude.ai/code/session_01HB79kL7YT15TDinp6Tvn9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01HB79kL7YT15TDinp6Tvn9v)_