### PR TITLE
26.2 Support

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -301,7 +301,12 @@ public enum ProtocolVersion implements Ordered<@NotNull ProtocolVersion> {
   /**
    * Minecraft 26.1 to 26.1.2.
    */
-  MINECRAFT_26_1(775, "26.1", "26.1.1", "26.1.2");
+  MINECRAFT_26_1(775, "26.1", "26.1.1", "26.1.2"),
+
+  /**
+   * Minecraft 26.2.
+   */
+  MINECRAFT_26_2(776, "26.2");
 
   /**
    * Bitmask shift used to encode snapshot protocol versions.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -98,8 +98,6 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
     ConnectedPlayer player = serverConn.getPlayer();
     VelocityServerConnection existingConnection = player.getConnectedServer();
 
-    packet.setOnlineMode(player.isOnlineMode());
-
     if (existingConnection != null) {
       // Shut down the existing server connection.
       player.setConnectedServer(null);
@@ -108,6 +106,9 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
       // Send keep alive to try to avoid timeouts
       player.sendKeepAlive();
     }
+
+    // Override online mode
+    packet.setOnlineMode(player.isOnlineMode());
 
     // Reset Tablist header and footer to prevent desync
     player.clearPlayerListHeaderAndFooter();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -98,6 +98,8 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
     ConnectedPlayer player = serverConn.getPlayer();
     VelocityServerConnection existingConnection = player.getConnectedServer();
 
+    packet.setOnlineMode(player.isOnlineMode());
+
     if (existingConnection != null) {
       // Shut down the existing server connection.
       player.setConnectedServer(null);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -342,6 +342,11 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
         success.setUsername(player.getUsername());
         success.setProperties(player.getGameProfileProperties());
         success.setUuid(player.getUniqueId());
+
+        if (inbound.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+          success.setSessionId(UUID.randomUUID()); // Use random UUID for now
+        }
+
         mcConnection.write(success);
 
         loginState = State.SUCCESS_SENT;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -390,10 +390,6 @@ public class JoinGamePacket implements MinecraftPacket {
     this.showRespawnScreen = buf.readBoolean();
     this.doLimitedCrafting = buf.readBoolean();
 
-    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
-      this.onlineMode = buf.readBoolean();
-    }
-
     String dimensionKey = "";
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
       dimension = ProtocolUtils.readVarInt(buf);
@@ -584,10 +580,6 @@ public class JoinGamePacket implements MinecraftPacket {
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
       ProtocolUtils.writeVarInt(buf, seaLevel);
-    }
-
-    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
-      buf.writeBoolean(this.onlineMode);
     }
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -215,6 +215,10 @@ public class JoinGamePacket implements MinecraftPacket {
     this.seaLevel = seaLevel;
   }
 
+  public void setOnlineMode(boolean onlineMode) {
+    this.onlineMode = onlineMode;
+  }
+
   public boolean getEnforcesSecureChat() {
     return this.enforcesSecureChat;
   }
@@ -251,6 +255,7 @@ public class JoinGamePacket implements MinecraftPacket {
         + ", lastDeathPosition='" + lastDeathPosition + '\''
         + ", portalCooldown=" + portalCooldown
         + ", seaLevel=" + seaLevel
+        + ", onlineMode=" + onlineMode
         + '}';
   }
 
@@ -417,6 +422,10 @@ public class JoinGamePacket implements MinecraftPacket {
       this.seaLevel = ProtocolUtils.readVarInt(buf);
     }
 
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      this.onlineMode = buf.readBoolean();
+    }
+
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
       this.enforcesSecureChat = buf.readBoolean();
     }
@@ -575,6 +584,10 @@ public class JoinGamePacket implements MinecraftPacket {
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
       ProtocolUtils.writeVarInt(buf, seaLevel);
+    }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      buf.writeBoolean(this.onlineMode);
     }
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -75,6 +75,8 @@ public class JoinGamePacket implements MinecraftPacket {
 
   private int seaLevel;
 
+  private boolean onlineMode;
+
   private boolean enforcesSecureChat;
 
   public int getEntityId() {
@@ -383,6 +385,10 @@ public class JoinGamePacket implements MinecraftPacket {
     this.showRespawnScreen = buf.readBoolean();
     this.doLimitedCrafting = buf.readBoolean();
 
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      this.onlineMode = buf.readBoolean();
+    }
+
     String dimensionKey = "";
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
       dimension = ProtocolUtils.readVarInt(buf);
@@ -569,6 +575,10 @@ public class JoinGamePacket implements MinecraftPacket {
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
       ProtocolUtils.writeVarInt(buf, seaLevel);
+    }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      buf.writeBoolean(this.onlineMode);
     }
 
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ServerLoginSuccessPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ServerLoginSuccessPacket.java
@@ -75,6 +75,10 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
     this.properties = properties;
   }
 
+  public void setSessionId(@Nullable UUID sessionId) {
+    this.sessionId = sessionId;
+  }
+
   @Override
   public String toString() {
     return "ServerLoginSuccess{"

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ServerLoginSuccessPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ServerLoginSuccessPacket.java
@@ -38,6 +38,8 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
 
   private @Nullable List<GameProfile.Property> properties;
 
+  private @Nullable UUID sessionId;
+
   private static final boolean strictErrorHandling = VelocityProperties
           .readBoolean("velocity.strictErrorHandling", true);
 
@@ -103,6 +105,10 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
     if (version == ProtocolVersion.MINECRAFT_1_20_5 || version == ProtocolVersion.MINECRAFT_1_21) {
       buf.readBoolean();
     }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      this.sessionId = ProtocolUtils.readUuid(buf);
+    }
   }
 
   @Override
@@ -137,6 +143,10 @@ public class ServerLoginSuccessPacket implements MinecraftPacket {
 
     if (version == ProtocolVersion.MINECRAFT_1_20_5 || version == ProtocolVersion.MINECRAFT_1_21) {
       buf.writeBoolean(strictErrorHandling);
+    }
+
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_26_2)) {
+      ProtocolUtils.writeUuid(buf, this.sessionId);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -24,6 +24,7 @@ import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_20_3;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_20_5;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_21_5;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_21_6;
+import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_26_2;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier.id;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier.mapSet;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.DoubleArgumentPropertySerializer.DOUBLE;
@@ -282,6 +283,7 @@ public final class ArgumentPropertyRegistry {
 
     empty(id("minecraft:hex_color", mapSet(MINECRAFT_1_21_6, 17))); // added in 1.21.6
     empty(id("minecraft:dialog", mapSet(MINECRAFT_1_21_6, 55))); // added in 1.21.6
+    empty(id("minecraft:team_color", mapSet(MINECRAFT_26_2, 16))); // added in 26.2
 
     // Cross-stitch support
     register(id("crossstitch:mod_argument", mapSet(MINECRAFT_1_19, -256)), ModArgumentProperty.class, MOD);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -209,18 +209,18 @@ public final class ArgumentPropertyRegistry {
     empty(id("minecraft:block_predicate", mapSet(MINECRAFT_1_19, 13)));
     empty(id("minecraft:item_stack", mapSet(MINECRAFT_1_19, 14)));
     empty(id("minecraft:item_predicate", mapSet(MINECRAFT_1_19, 15)));
-    empty(id("minecraft:color", mapSet(MINECRAFT_1_19, 16)));
+    empty(id("minecraft:color", mapSet(MINECRAFT_26_2, -1), mapSet(MINECRAFT_1_19, 16))); // Renamed to team_color in 26.2
     empty(id("minecraft:component", mapSet(MINECRAFT_1_21_6, 18), mapSet(MINECRAFT_1_19, 17)));
-    empty(id("minecraft:style", mapSet(MINECRAFT_1_21_6, 19), mapSet(MINECRAFT_1_20_3, 18))); // added 1.20.3
+    empty(id("minecraft:style", mapSet(MINECRAFT_1_21_6, 19), mapSet(MINECRAFT_1_20_3, 18))); // Added 1.20.3
     empty(id("minecraft:message", mapSet(MINECRAFT_1_21_6, 20), mapSet(MINECRAFT_1_20_3, 19), mapSet(MINECRAFT_1_19, 18)));
-    empty(id("minecraft:nbt_compound_tag", mapSet(MINECRAFT_1_21_6, 21), mapSet(MINECRAFT_1_20_3, 20), mapSet(MINECRAFT_1_19, 19))); // added in 1.14
-    empty(id("minecraft:nbt_tag", mapSet(MINECRAFT_1_21_6, 22), mapSet(MINECRAFT_1_20_3, 21), mapSet(MINECRAFT_1_19, 20))); // added in 1.14
+    empty(id("minecraft:nbt_compound_tag", mapSet(MINECRAFT_1_21_6, 21), mapSet(MINECRAFT_1_20_3, 20), mapSet(MINECRAFT_1_19, 19))); // Added in 1.14
+    empty(id("minecraft:nbt_tag", mapSet(MINECRAFT_1_21_6, 22), mapSet(MINECRAFT_1_20_3, 21), mapSet(MINECRAFT_1_19, 20))); // Added in 1.14
     empty(id("minecraft:nbt_path", mapSet(MINECRAFT_1_21_6, 23), mapSet(MINECRAFT_1_20_3, 22), mapSet(MINECRAFT_1_19, 21)));
     empty(id("minecraft:objective", mapSet(MINECRAFT_1_21_6, 24), mapSet(MINECRAFT_1_20_3, 23), mapSet(MINECRAFT_1_19, 22)));
     empty(id("minecraft:objective_criteria", mapSet(MINECRAFT_1_21_6, 25), mapSet(MINECRAFT_1_20_3, 24), mapSet(MINECRAFT_1_19, 23)));
     empty(id("minecraft:operation", mapSet(MINECRAFT_1_21_6, 26), mapSet(MINECRAFT_1_20_3, 25), mapSet(MINECRAFT_1_19, 24)));
     empty(id("minecraft:particle", mapSet(MINECRAFT_1_21_6, 27), mapSet(MINECRAFT_1_20_3, 26), mapSet(MINECRAFT_1_19, 25)));
-    empty(id("minecraft:angle", mapSet(MINECRAFT_1_21_6, 28), mapSet(MINECRAFT_1_20_3, 27), mapSet(MINECRAFT_1_19, 26))); // added in 1.16.2
+    empty(id("minecraft:angle", mapSet(MINECRAFT_1_21_6, 28), mapSet(MINECRAFT_1_20_3, 27), mapSet(MINECRAFT_1_19, 26))); // Added in 1.16.2
     empty(id("minecraft:rotation", mapSet(MINECRAFT_1_21_6, 29), mapSet(MINECRAFT_1_20_3, 28), mapSet(MINECRAFT_1_19, 27)));
     empty(id("minecraft:scoreboard_slot", mapSet(MINECRAFT_1_21_6, 30), mapSet(MINECRAFT_1_20_3, 29), mapSet(MINECRAFT_1_19, 28)));
     empty(id("minecraft:score_holder", mapSet(MINECRAFT_1_21_6, 31), mapSet(MINECRAFT_1_20_3, 30), mapSet(MINECRAFT_1_19, 29)),
@@ -248,7 +248,7 @@ public final class ArgumentPropertyRegistry {
         mapSet(MINECRAFT_1_19_3, 39))); // 1.19.3
 
     empty(id("minecraft:time", mapSet(MINECRAFT_1_21_6, 43), mapSet(MINECRAFT_1_20_5, 42), mapSet(MINECRAFT_1_20_3, 41),
-        mapSet(MINECRAFT_1_19_3, 40), mapSet(MINECRAFT_1_19, 42)), TimeArgumentSerializer.TIME); // added in 1.14
+        mapSet(MINECRAFT_1_19_3, 40), mapSet(MINECRAFT_1_19, 42)), TimeArgumentSerializer.TIME); // Added in 1.14
 
     register(id("minecraft:resource_or_tag", mapSet(MINECRAFT_1_21_6, 44), mapSet(MINECRAFT_1_20_5, 43), mapSet(MINECRAFT_1_20_3, 42),
         mapSet(MINECRAFT_1_19_3, 41), mapSet(MINECRAFT_1_19, 43)), RegistryKeyArgument.class, RegistryKeyArgumentSerializer.REGISTRY);
@@ -275,15 +275,15 @@ public final class ArgumentPropertyRegistry {
         mapSet(MINECRAFT_1_19_4, 47))); // 1.19.4
 
     empty(id("minecraft:uuid", mapSet(MINECRAFT_1_21_6, 56), mapSet(MINECRAFT_1_21_5, 54), mapSet(MINECRAFT_1_20_5, 53), mapSet(MINECRAFT_1_20_3, 48),
-        mapSet(MINECRAFT_1_19_4, 48), mapSet(MINECRAFT_1_19, 47))); // added in 1.16
+        mapSet(MINECRAFT_1_19_4, 48), mapSet(MINECRAFT_1_19, 47))); // Added in 1.16
 
     empty(id("minecraft:loot_table", mapSet(MINECRAFT_1_21_6, 52), mapSet(MINECRAFT_1_21_5, 51), mapSet(MINECRAFT_1_20_5, 50)));
     empty(id("minecraft:loot_predicate", mapSet(MINECRAFT_1_21_6, 53), mapSet(MINECRAFT_1_21_5, 52), mapSet(MINECRAFT_1_20_5, 51)));
     empty(id("minecraft:loot_modifier", mapSet(MINECRAFT_1_21_6, 54), mapSet(MINECRAFT_1_21_5, 53), mapSet(MINECRAFT_1_20_5, 52)));
 
-    empty(id("minecraft:hex_color", mapSet(MINECRAFT_1_21_6, 17))); // added in 1.21.6
-    empty(id("minecraft:dialog", mapSet(MINECRAFT_1_21_6, 55))); // added in 1.21.6
-    empty(id("minecraft:team_color", mapSet(MINECRAFT_26_2, 16))); // added in 26.2
+    empty(id("minecraft:hex_color", mapSet(MINECRAFT_1_21_6, 17))); // Added in 1.21.6
+    empty(id("minecraft:dialog", mapSet(MINECRAFT_1_21_6, 55))); // Added in 1.21.6
+    empty(id("minecraft:team_color", mapSet(MINECRAFT_26_2, 16))); // Renamed from color in 26.2
 
     // Cross-stitch support
     register(id("crossstitch:mod_argument", mapSet(MINECRAFT_1_19, -256)), ModArgumentProperty.class, MOD);


### PR DESCRIPTION
The protocol numbers seem to increment by one/version at this time, so let's not mark snapshot builds since extra modifications aren't required.

Note: Minecraft 26.2 proposes a June 16th release date; however, Velocity generally merges these protocol bumps in advance nowadays.