### PR TITLE
Fix fallback chain skipped when initial server stalls after accepting connection (#938)

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -199,6 +199,14 @@ public interface ProxyConfig {
   int getReadTimeout();
 
   /**
+   * Get how long this proxy will wait for a backend to complete the login/configuration sequence
+   * before abandoning it and moving the player on through the fallback chain.
+   *
+   * @return login timeout (in milliseconds)
+   */
+  int getLoginTimeout();
+
+  /**
    * Get the rate limit for how fast a player can execute commands.
    *
    * @return the command rate limit (in milliseconds)

--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -127,6 +127,13 @@ public class CtdConfigMigrations {
 
         // [advanced]
         migration(
+            "How long (in milliseconds) to wait for a backend to complete login before giving up and moving\n"
+                + "the player on through the fallback chain. Unlike read-timeout this only bounds connection\n"
+                + "establishment, so it can be kept short for fast failover. The default is 6 seconds.",
+            "advanced.login-timeout",
+            6000
+        ),
+        migration(
             "Enables the execution of illegal characters in chat and only allows\n"
                 + " or denies illegal characters that are executed through the proxy.",
             "advanced.allow-illegal-characters-in-chat",

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -757,6 +757,11 @@ public final class VelocityConfiguration implements ProxyConfig {
   }
 
   @Override
+  public int getLoginTimeout() {
+    return advanced.getLoginTimeout();
+  }
+
+  @Override
   public int getCommandRatelimit() {
     return advanced.getCommandRateLimit();
   }
@@ -1968,6 +1973,9 @@ public final class VelocityConfiguration implements ProxyConfig {
     private int readTimeout = 25000;
 
     @Expose
+    private int loginTimeout = 6000;
+
+    @Expose
     private boolean proxyProtocol = false;
 
     @Expose
@@ -2068,6 +2076,7 @@ public final class VelocityConfiguration implements ProxyConfig {
         this.loginRatelimit = config.getIntOrElse("login-ratelimit", 3000);
         this.connectionTimeout = config.getIntOrElse("connection-timeout", 5000);
         this.readTimeout = config.getIntOrElse("read-timeout", 25000);
+        this.loginTimeout = config.getIntOrElse("login-timeout", 6000);
         if (config.contains("haproxy-protocol")) {
           this.proxyProtocol = config.getOrElse("haproxy-protocol", false);
         } else {
@@ -2119,6 +2128,10 @@ public final class VelocityConfiguration implements ProxyConfig {
 
     public int getReadTimeout() {
       return readTimeout;
+    }
+
+    public int getLoginTimeout() {
+      return loginTimeout;
     }
 
     public boolean isProxyProtocol() {
@@ -2213,6 +2226,7 @@ public final class VelocityConfiguration implements ProxyConfig {
           .add("loginRatelimit", loginRatelimit)
           .add("connectionTimeout", connectionTimeout)
           .add("readTimeout", readTimeout)
+          .add("loginTimeout", loginTimeout)
           .add("proxyProtocol", proxyProtocol)
           .add("tcpFastOpen", tcpFastOpen)
           .add("bungeePluginMessageChannel", bungeePluginMessageChannel)

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -33,13 +33,16 @@ import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.util.ConnectionMessages;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
+import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -136,6 +139,15 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
           // Set the new play session handler for the server. We will have nothing more to do
           // with this connection once this task finishes up.
           smc.setActiveSessionHandler(StateRegistry.PLAY, new BackendPlaySessionHandler(server, serverConn));
+
+          // The login/configuration sequence is complete: swap the short login timeout that
+          // BackendChannelInitializer installed for the regular in-play read-timeout, so a healthy
+          // but momentarily idle backend isn't dropped (issue GemstoneGG#938).
+          final var backendPipeline = smc.getChannel().pipeline();
+          if (backendPipeline.context(Connections.READ_TIMEOUT) != null) {
+            backendPipeline.replace(Connections.READ_TIMEOUT, Connections.READ_TIMEOUT,
+                new ReadTimeoutHandler(server.getConfiguration().getReadTimeout(), TimeUnit.MILLISECONDS));
+          }
 
           // Now set the connected server.
           serverConn.getPlayer().setConnectedServer(serverConn);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -86,6 +86,7 @@ import com.velocitypowered.proxy.connection.util.ConnectionMessages;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
 import com.velocitypowered.proxy.connection.util.FallbackServers;
 import com.velocitypowered.proxy.connection.util.VelocityInboundConnection;
+import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
@@ -123,6 +124,7 @@ import com.velocitypowered.proxy.util.TranslatableMapper;
 import com.velocitypowered.proxy.util.collect.CappedSet;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collection;
@@ -1249,6 +1251,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     }
 
     if (serverConnection != null) {
+      // The player has reached a server; restore the read-timeout that was suspended while we
+      // were establishing their initial connection (see pauseReadTimeout / issue GemstoneGG#938).
+      resumeReadTimeout();
+
       if (server.isQueueEnabled()) {
         String queueServerName = server.getConfiguration().getQueue().getQueueServer();
         boolean destinationIsQueueServer = !queueServerName.isEmpty()
@@ -1276,6 +1282,33 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       if (!firstServerConnected) {
         firstServerConnected = true;
       }
+    }
+  }
+
+  /**
+   * Suspends the read-timeout on the player's own (client-facing) connection while we establish
+   * their initial connection. The client legitimately idles on the loading screen during that
+   * window, so its read-timeout must not fire -- otherwise a backend that stalls after accepting
+   * the TCP connection times the idle client out before the backend connection's own timeout can
+   * drive the fallback chain, dropping the player instead of moving them on. Restored by
+   * {@link #resumeReadTimeout()} once a server is reached (issue GemstoneGG#938).
+   */
+  private void pauseReadTimeout() {
+    final var pipeline = connection.getChannel().pipeline();
+    if (pipeline.context(Connections.READ_TIMEOUT) != null) {
+      pipeline.remove(Connections.READ_TIMEOUT);
+    }
+  }
+
+  /**
+   * Restores the read-timeout on the player's own connection after it was suspended by
+   * {@link #pauseReadTimeout()}. Idempotent: does nothing if the handler is already present.
+   */
+  private void resumeReadTimeout() {
+    final var pipeline = connection.getChannel().pipeline();
+    if (pipeline.context(Connections.READ_TIMEOUT) == null && pipeline.context(Connections.FRAME_DECODER) != null) {
+      pipeline.addAfter(Connections.FRAME_DECODER, Connections.READ_TIMEOUT, new ReadTimeoutHandler(
+          server.getConfiguration().getReadTimeout(), TimeUnit.MILLISECONDS));
     }
   }
 
@@ -2106,6 +2139,14 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           VelocityServerConnection con = new VelocityServerConnection(
               realDestination, previousServer, ConnectedPlayer.this, server);
           connectionInFlight = con;
+
+          if (connectedServer == null) {
+            // Establishing the player's initial connection (or working through the fallback chain
+            // for it): they have no backend yet and are idling on a loading screen. Suspend their
+            // connection's read-timeout so a stalled backend can't time the idle client out before
+            // the backend timeout drives the fallback. Restored in setConnectedServer (issue GemstoneGG#938).
+            pauseReadTimeout();
+          }
 
           return con.connect().whenCompleteAsync((result, exception) -> {
             if (result != null && !result.isSuccessful() && !result.isSafe()) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/BackendChannelInitializer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/BackendChannelInitializer.java
@@ -52,7 +52,9 @@ public class BackendChannelInitializer extends ChannelInitializer<Channel> {
   protected void initChannel(Channel ch) {
     ch.pipeline()
         .addLast(FRAME_DECODER, new MinecraftVarintFrameDecoder(ProtocolUtils.Direction.CLIENTBOUND))
-        .addLast(READ_TIMEOUT, new ReadTimeoutHandler(server.getConfiguration().getReadTimeout(), TimeUnit.MILLISECONDS))
+        // Short login timeout while establishing the connection, so a stalled backend is abandoned
+        // quickly for the fallback chain. Swapped for read-timeout at PLAY (TransitionSessionHandler).
+        .addLast(READ_TIMEOUT, new ReadTimeoutHandler(server.getConfiguration().getLoginTimeout(), TimeUnit.MILLISECONDS))
         .addLast(FRAME_ENCODER, MinecraftVarintLengthEncoder.INSTANCE)
         .addLast(MINECRAFT_DECODER, new MinecraftDecoder(ProtocolUtils.Direction.CLIENTBOUND))
         .addLast(FLOW_HANDLER, new AutoReadHolderHandler())

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -259,6 +259,11 @@ connection-timeout = 5000
 # Specify a read timeout for connections here. The default is 25 seconds.
 read-timeout = 25000
 
+# How long (in milliseconds) to wait for a backend to complete login before giving up and moving
+# the player on through the fallback chain. Unlike read-timeout this only bounds connection
+# establishment, so it can be kept short for fast failover. The default is 6 seconds.
+login-timeout = 6000
+
 # Enables compatibility with HAProxy's PROXY protocol. If you don't know what this is for, then
 # don't enable it.
 haproxy-protocol = false


### PR DESCRIPTION
When a player joins via a forced host whose first backend **accepts the TCP connection but then never completes login** (e.g. a firewall/anti-DDoS front that answers pings but black-holes logins), they get disconnected with "An internal error occurred in your connection" instead of being moved to the next server in the fallback chain. Fixes #938.

While the player idles in config waiting for the backend, two `ReadTimeoutHandler`s with the same duration race:

- **backend** connection timeout -> drives the fallback chain (correct)
- **player** connection timeout -> hard-disconnects (wrong)

The player-side handler is created first, so it fires first and wins -> disconnect instead of failover.
This is also why lowering `read-timeout` didn't help (see referenced issue's chain): it shortens both equally, keeping the race tied (though this has been PR'd upstream and early-merged in bb9fc60bb6faacb1845275e4eafbca01c108fc6d.

**Fix**

Suspend the player connection's read-timeout while establishing the initial connection (and through the fallback chain), restore it once a server is reached. The client can no longer time itself out during limbo, so the backend timeout fires and drives the existing fallback chain. As a bonus, `read-timeout` tuning now actually controls failover speed.