### PR TITLE
Resend command tree on permission change

### DIFF
--- a/api/src/main/java/com/velocityctd/api/permission/PermissionChangeListener.java
+++ b/api/src/main/java/com/velocityctd/api/permission/PermissionChangeListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Velocity-CTD Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocityctd.api.permission;
+
+/**
+ * A listener that is notified when the effective permissions of a {@link PermissionResolver}'s
+ * subject change.
+ *
+ * <p>Register one through
+ * {@link PermissionResolver#subscribeToPermissionChanges(PermissionChangeListener)}. Resolvers
+ * backed by a permission system capable of emitting change notifications (such as LuckPerms) deliver
+ * those notifications to this listener.
+ */
+@FunctionalInterface
+public interface PermissionChangeListener {
+
+  /**
+   * Called when the effective permissions of the resolver's subject have changed.
+   *
+   * <p>This method may be invoked from an arbitrary thread, depending on the underlying permission
+   * system. Implementations are responsible for any thread confinement they require.
+   *
+   * <p>Resolvers may coalesce a rapid burst of changes into a single invocation, so this method is
+   * not guaranteed to be called once per underlying change.
+   */
+  void onPermissionChange();
+}

--- a/api/src/main/java/com/velocityctd/api/permission/PermissionResolver.java
+++ b/api/src/main/java/com/velocityctd/api/permission/PermissionResolver.java
@@ -53,4 +53,26 @@ public interface PermissionResolver extends PermissionFunction {
   @Nullable
   @Unmodifiable
   Map<String, Boolean> getPermissionMap();
+
+  /**
+   * Subscribes the given {@link PermissionChangeListener} to changes in this resolver's subject's
+   * effective permissions.
+   *
+   * <p>If the underlying permission system supports change notifications, the listener should be
+   * invoked when the subject's effective permissions change. Resolvers that cannot emit such
+   * notifications should leave this method as the default no-op.
+   *
+   * <p>Resolvers should avoid spamming the listener: a burst of changes that amount to a single
+   * logical change should be coalesced into a single invocation. Multiple listeners may be
+   * registered.
+   *
+   * @param listener the listener to notify of permission changes
+   * @return an {@link AutoCloseable} that unsubscribes the listener when closed. Callers should close
+   *         it once the listener is no longer needed to stop notifications and release any resources
+   *         held for the subscription. The default implementation returns a no-op handle.
+   */
+  default @NonNull AutoCloseable subscribeToPermissionChanges(PermissionChangeListener listener) {
+    return () -> {
+    };
+  }
 }

--- a/luckperms-integration/src/main/java/com/velocityctd/proxy/permission/luckperms/LuckpermsPermissionChangeDispatcher.java
+++ b/luckperms-integration/src/main/java/com/velocityctd/proxy/permission/luckperms/LuckpermsPermissionChangeDispatcher.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 Velocity-CTD Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocityctd.proxy.permission.luckperms;
+
+import com.velocityctd.api.permission.PermissionChangeListener;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.event.user.UserDataRecalculateEvent;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Bridges LuckPerms' {@link UserDataRecalculateEvent} to {@link PermissionChangeListener}s.
+ */
+final class LuckpermsPermissionChangeDispatcher {
+
+  private static final System.Logger LOGGER =
+      System.getLogger(LuckpermsPermissionChangeDispatcher.class.getName());
+
+  private static final long COOLDOWN_MILLIS = 100L;
+
+  // Values are copy-on-write: a published Set is never mutated in place, so dispatch can iterate the
+  // snapshot it reads from the map without locking. The common single-listener case avoids
+  // allocating a backing Set by storing a `Collections.singleton()`.
+  private final ConcurrentMap<UUID, Set<Registration>> registrations = new ConcurrentHashMap<>();
+
+  LuckpermsPermissionChangeDispatcher(LuckPerms api) {
+    //noinspection resource
+    api.getEventBus().subscribe(UserDataRecalculateEvent.class, this::onRecalculate);
+  }
+
+  /**
+   * Registers a listener for changes to the given subject's permissions.
+   *
+   * @param subjectId the subject (player) unique id
+   * @param listener the listener to notify
+   * @return a handle that unregisters the listener when closed
+   */
+  AutoCloseable register(UUID subjectId, PermissionChangeListener listener) {
+    Registration registration = new Registration(subjectId, listener);
+    registrations.compute(subjectId, (id, existing) -> {
+      if (existing == null) {
+        return Collections.singleton(registration);
+      }
+      Set<Registration> expanded = new HashSet<>(existing);
+      expanded.add(registration);
+      return expanded;
+    });
+    return registration;
+  }
+
+  private void onRecalculate(UserDataRecalculateEvent event) {
+    Set<Registration> subjectRegistrations = registrations.get(event.getUser().getUniqueId());
+    if (subjectRegistrations == null) {
+      return;
+    }
+
+    for (Registration registration : subjectRegistrations) {
+      registration.notifyChanged();
+    }
+  }
+
+  private void unregister(Registration registration) {
+    registrations.computeIfPresent(registration.subjectId, (id, existing) -> {
+      if (existing.size() == 1) {
+        return existing.contains(registration) ? null : existing;
+      }
+      Set<Registration> reduced = new HashSet<>(existing);
+      reduced.remove(registration);
+      return reduced;
+    });
+  }
+
+  /**
+   * A single listener registration. Debounces deliveries so that a burst of recalculations for one
+   * subject results in a single notification, and unregisters itself when closed.
+   */
+  private final class Registration implements AutoCloseable {
+
+    private final UUID subjectId;
+    private final PermissionChangeListener listener;
+    private @Nullable CompletableFuture<Void> pending;
+    private boolean closed;
+
+    Registration(UUID subjectId, PermissionChangeListener listener) {
+      this.subjectId = subjectId;
+      this.listener = listener;
+    }
+
+    synchronized void notifyChanged() {
+      if (closed) {
+        return;
+      }
+
+      if (pending != null) {
+        pending.cancel(false);
+      }
+
+      CompletableFuture<Void> scheduled = CompletableFuture.runAsync(
+          listener::onPermissionChange,
+          CompletableFuture.delayedExecutor(COOLDOWN_MILLIS, TimeUnit.MILLISECONDS));
+      scheduled.whenComplete((result, throwable) -> {
+        if (throwable != null && !(throwable instanceof CancellationException)) {
+          LOGGER.log(System.Logger.Level.ERROR, "A permission change listener threw an exception.", throwable);
+        }
+      });
+      pending = scheduled;
+    }
+
+    @Override
+    public synchronized void close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      if (pending != null) {
+        pending.cancel(false);
+      }
+      unregister(this);
+    }
+  }
+}

--- a/luckperms-integration/src/main/java/com/velocityctd/proxy/permission/luckperms/LuckpermsPermissionResolver.java
+++ b/luckperms-integration/src/main/java/com/velocityctd/proxy/permission/luckperms/LuckpermsPermissionResolver.java
@@ -17,6 +17,7 @@
 
 package com.velocityctd.proxy.permission.luckperms;
 
+import com.velocityctd.api.permission.PermissionChangeListener;
 import com.velocityctd.api.permission.PermissionResolver;
 import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.Tristate;
@@ -34,10 +35,11 @@ import org.jetbrains.annotations.Unmodifiable;
  * to LuckPerm's {@link PermissionFunction#getPermissionValue(String)} implementation, and provides more
  * advanced permission methods through the use of the LuckPerms API.
  */
-public final class LuckpermsPermissionResolver implements PermissionResolver {
+final class LuckpermsPermissionResolver implements PermissionResolver {
 
   private final Player player;
   private final PermissionFunction delegate;
+  private final LuckpermsPermissionChangeDispatcher changeDispatcher;
 
   /**
    * Instantiates a {@link LuckpermsPermissionResolver}.
@@ -45,10 +47,13 @@ public final class LuckpermsPermissionResolver implements PermissionResolver {
    * @param player the Velocity player
    * @param delegate the LuckPerms PermissionFunction delegate. It's expected, though not required, that this
    *                 is a {@code me.lucko.luckperms.velocity.service.PlayerPermissionProvider}.
+   * @param changeDispatcher the dispatcher used to register permission change listeners for this player
    */
-  LuckpermsPermissionResolver(Player player, PermissionFunction delegate) {
+  LuckpermsPermissionResolver(Player player, PermissionFunction delegate,
+      LuckpermsPermissionChangeDispatcher changeDispatcher) {
     this.player = player;
     this.delegate = delegate;
+    this.changeDispatcher = changeDispatcher;
   }
 
   @Override
@@ -63,5 +68,10 @@ public final class LuckpermsPermissionResolver implements PermissionResolver {
 
     QueryOptions queryOptions = api.getContextManager().getQueryOptions(player);
     return user.getCachedData().getPermissionData(queryOptions).getPermissionMap();
+  }
+
+  @Override
+  public AutoCloseable subscribeToPermissionChanges(PermissionChangeListener listener) {
+    return changeDispatcher.register(player.getUniqueId(), listener);
   }
 }

--- a/luckperms-integration/src/main/java/com/velocityctd/proxy/permission/luckperms/LuckpermsPermissionResolverProvider.java
+++ b/luckperms-integration/src/main/java/com/velocityctd/proxy/permission/luckperms/LuckpermsPermissionResolverProvider.java
@@ -22,6 +22,7 @@ import com.velocityctd.api.permission.PermissionResolverProvider;
 import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.PermissionSubject;
 import com.velocitypowered.api.proxy.Player;
+import net.luckperms.api.LuckPermsProvider;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -31,6 +32,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * if we have the LuckPerms plugin installed and available for the advanced permission checks.
  */
 public final class LuckpermsPermissionResolverProvider implements PermissionResolverProvider {
+
+  private @Nullable LuckpermsPermissionChangeDispatcher changeDispatcher;
 
   @Override
   public boolean isAvailable() {
@@ -48,6 +51,14 @@ public final class LuckpermsPermissionResolverProvider implements PermissionReso
       return null;
     }
 
-    return new LuckpermsPermissionResolver(player, delegate);
+    return new LuckpermsPermissionResolver(player, delegate, changeDispatcher());
+  }
+
+  private synchronized LuckpermsPermissionChangeDispatcher changeDispatcher() {
+    if (changeDispatcher == null) {
+      changeDispatcher = new LuckpermsPermissionChangeDispatcher(LuckPermsProvider.get());
+    }
+
+    return changeDispatcher;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -205,10 +205,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   private GameProfile profile;
 
-  /**
-   * The permission resolver used to evaluate permission checks for this player.
-   */
   private PermissionResolver permissionResolver;
+
+  private @Nullable AutoCloseable permissionSubscription;
 
   private long ping = -1;
 
@@ -360,6 +359,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
    * Used for cleaning up resources during a disconnection.
    */
   public void disconnected() {
+    closePermissionSubscription();
+
     for (VelocityBossBarImplementation bar : this.bossBars) {
       bar.viewerDisconnected(this);
     }
@@ -537,10 +538,30 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   void setPermissionFunction(PermissionFunction permissionFunction) {
+    closePermissionSubscription();
+
     if (permissionFunction instanceof PermissionResolver resolver) {
       this.permissionResolver = resolver;
     } else {
       this.permissionResolver = createPermissionResolverAdapter(this, permissionFunction);
+    }
+
+    // Refresh the command tree whenever the resolver reports a permission change, since a player may
+    // gain or lose access to proxy commands.
+    this.permissionSubscription = this.permissionResolver.subscribeToPermissionChanges(this::sendAvailableCommands);
+  }
+
+  private void closePermissionSubscription() {
+    if (this.permissionSubscription == null) {
+      return;
+    }
+
+    try {
+      this.permissionSubscription.close();
+    } catch (Exception e) {
+      LOGGER.warn("Could not close permission change subscription for {}.", this, e);
+    } finally {
+      this.permissionSubscription = null;
     }
   }
 


### PR DESCRIPTION
- Introduce `PermissionResolver#subscribeToPermissionChanges`
- Implement this in `luckperms-integration`
- Use it in `ConnectedPlayer` to re-send the command tree on permission changes
