### PR TITLE
Introduce and fire `PermissionsChangeEvent`

### DIFF
--- a/api/src/main/java/com/velocityctd/api/event/permission/PermissionsChangeEvent.java
+++ b/api/src/main/java/com/velocityctd/api/event/permission/PermissionsChangeEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Velocity-CTD Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocityctd.api.event.permission;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.Player;
+
+/**
+ * This event is fired when the effective permissions of a connected {@link Player} change, for
+ * example when their groups or directly-assigned permissions are modified by a permission plugin.
+ * Velocity will not wait on this event to finish firing.
+ *
+ * <p>This event requires the player's permission provider to report permission changes (such as
+ * LuckPerms through Velocity-CTD's integration). It may be fired from an arbitrary thread, and rapid
+ * successive changes for the same player may be coalesced into a single event.
+ */
+public final class PermissionsChangeEvent {
+
+  /**
+   * The player whose effective permissions changed.
+   */
+  private final Player player;
+
+  /**
+   * Constructs a new {@code PermissionsChangeEvent}.
+   *
+   * @param player the player whose permissions changed
+   */
+  public PermissionsChangeEvent(Player player) {
+    this.player = Preconditions.checkNotNull(player, "player");
+  }
+
+  /**
+   * Returns the player whose effective permissions changed.
+   *
+   * @return the player
+   */
+  public Player getPlayer() {
+    return player;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("player", player)
+        .toString();
+  }
+}

--- a/api/src/main/java/com/velocityctd/api/event/permission/package-info.java
+++ b/api/src/main/java/com/velocityctd/api/event/permission/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2026 Velocity-CTD Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+/**
+ * Provides events related to changes in player permissions.
+ */
+package com.velocityctd.api.event.permission;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -29,6 +29,7 @@ import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
+import com.velocityctd.api.event.permission.PermissionsChangeEvent;
 import com.velocityctd.api.permission.PermissionResolver;
 import com.velocityctd.api.queue.QueueState;
 import com.velocityctd.proxy.permission.PermissionUtils;
@@ -546,9 +547,15 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       this.permissionResolver = createPermissionResolverAdapter(this, permissionFunction);
     }
 
+    this.permissionSubscription = this.permissionResolver.subscribeToPermissionChanges(this::onPermissionsChange);
+  }
+
+  private void onPermissionsChange() {
+    server.getEventManager().fireAndForget(new PermissionsChangeEvent(this));
+
     // Refresh the command tree whenever the resolver reports a permission change, since a player may
     // gain or lose access to proxy commands.
-    this.permissionSubscription = this.permissionResolver.subscribeToPermissionChanges(this::sendAvailableCommands);
+    sendAvailableCommands();
   }
 
   private void closePermissionSubscription() {


### PR DESCRIPTION
Introduce CTD-native `com.velocityctd.api.event.permission.PermissionsChangeEvent` and fire this event once a player's permissions change.