### PR TITLE
Reimplement server reconcile logic during `/velocity reload` 

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/RedisVelocityQueueManager.java
@@ -160,6 +160,13 @@ public final class RedisVelocityQueueManager extends VelocityQueueManager {
   }
 
   @Override
+  protected void onQueueRemoved(@NotNull String serverName) {
+    if (isMasterProxy() && !server.getRedis().isShutdown()) {
+      server.getRedis().getQueueService().removeQueue(serverName);
+    }
+  }
+
+  @Override
   public @NotNull RedisVelocityQueue getQueue(@NotNull String serverName) {
     return (RedisVelocityQueue) super.getQueue(serverName);
   }

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
@@ -174,7 +174,45 @@ public class VelocityQueueManager implements QueueManager {
 
   @Override
   public void reload() {
+    reconcileQueues();
     rescheduleTasks();
+  }
+
+  protected void reconcileQueues() {
+    Set<String> registered = new HashSet<>();
+    for (VelocityRegisteredServer rs : server.getAllServers()) {
+      registered.add(rs.getServerInfo().getName());
+    }
+
+    // Drop queues whose backing server no longer exists.
+    for (Map.Entry<String, VelocityQueue<?>> entry : new HashMap<>(queues).entrySet()) {
+      if (registered.contains(entry.getKey())) {
+        continue;
+      }
+
+      entry.getValue().teardown();
+      queues.remove(entry.getKey());
+      LAST_TURNED_ONLINE_TIME.remove(entry.getKey());
+      onQueueRemoved(entry.getKey());
+    }
+
+    // Create queues for newly-added servers.
+    for (VelocityRegisteredServer rs : server.getAllServers()) {
+      String name = rs.getServerInfo().getName();
+      queues.computeIfAbsent(name, n -> {
+        boolean inactive = server.getConfiguration().getQueue().getNoQueueServers().contains(n);
+        return createQueue(rs, inactive ? QueueState.INACTIVE : QueueState.ACTIVE);
+      });
+    }
+  }
+
+  /**
+   * Called after a queue has been removed during {@link #reconcileQueues()}.
+   *
+   * @param serverName the name of the server whose queue was removed
+   */
+  protected void onQueueRemoved(@NotNull String serverName) {
+    // no-op
   }
 
   @Override

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/redis/depot/VelocityQueueDepotService.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/redis/depot/VelocityQueueDepotService.java
@@ -49,4 +49,13 @@ public final class VelocityQueueDepotService
   public void upsertQueue(@NotNull RedisVelocityQueue queue) {
     this.depot.upsert(new VelocityQueueDepotEntry(queue));
   }
+
+  /**
+   * Removes the persisted snapshot for the given server's queue from Redis.
+   *
+   * @param serverName the name of the server whose queue snapshot should be removed
+   */
+  public void removeQueue(@NotNull String serverName) {
+    this.depot.remove(serverName);
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -74,6 +74,7 @@ import com.velocitypowered.proxy.command.builtin.VelocityCommand;
 import com.velocitypowered.proxy.config.DynamicProxyFilterMode;
 import com.velocitypowered.proxy.config.ProxyAddress;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.client.PlayerRegistry;
 import com.velocitypowered.proxy.connection.player.resourcepack.TransferPackSecret;
@@ -121,6 +122,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -601,57 +603,13 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
     this.configuration = newConfiguration;
 
-    reloadServerList();
+    reconcileServers(newConfiguration);
 
     registerCommands();
 
     translationRegistryManager.unregisterTranslations();
 
     translationRegistryManager.registerTranslations();
-
-    // Re-register servers. If a server is being replaced, make sure to note what players need to
-    // move back to a fallback server.
-    Collection<ConnectedPlayer> evacuate = new ArrayList<>();
-    for (Map.Entry<String, BackendServerConfig> entry : newConfiguration.getBackendServers().entrySet()) {
-      ServerInfo newInfo = new ServerInfo(entry.getKey(), AddressUtil.parseAddress(entry.getValue().address()), entry.getValue().forwardingMode());
-      Optional<VelocityRegisteredServer> rs = servers.getServer(entry.getKey());
-      if (rs.isEmpty()) {
-        servers.register(newInfo);
-      } else if (!rs.get().getServerInfo().equals(newInfo)) {
-        evacuate.addAll(rs.get().getPlayersConnected());
-
-        servers.unregister(rs.get().getServerInfo());
-        servers.register(newInfo);
-      }
-    }
-
-    // If we had any players to evacuate, let's move them now. Wait until they are all moved off.
-    if (!evacuate.isEmpty()) {
-      CountDownLatch latch = new CountDownLatch(evacuate.size());
-      for (ConnectedPlayer player : evacuate) {
-        Optional<VelocityRegisteredServer> next = player.currentServerRetrySession().getNextServerToTry();
-        if (next.isPresent()) {
-          player.createConnectionRequest(next.get()).connectWithIndication()
-              .whenComplete((success, ex) -> {
-                if (ex != null || success == null || !success) {
-                  player.disconnect(Component.text("Your server has been changed, but we could "
-                      + "not move you to any fallback servers."));
-                }
-                latch.countDown();
-              });
-        } else {
-          latch.countDown();
-          player.disconnect(Component.text("Your server has been changed, but we could "
-              + "not move you to any fallback servers."));
-        }
-      }
-      try {
-        latch.await();
-      } catch (InterruptedException e) {
-        LOGGER.error("Interrupted whilst moving players", e);
-        Thread.currentThread().interrupt();
-      }
-    }
 
     // If we have a new bind address, bind to it
     if (!configuration.getBind().equals(newConfiguration.getBind())) {
@@ -837,45 +795,155 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     return aliases.toArray(String[]::new);
   }
 
-  /**
-   * Reloads the list of servers based on the updated configuration.
-   *
-   * <p>This is exclusively implemented within VelocityServer as it
-   * is not a function necessary and present for generic purposes
-   * within ServerCommand and is exclusive to reload's functionality.</p>
-   */
-  public void reloadServerList() {
-    VelocityConfiguration config = getConfiguration();
-    List<ServerInfo> newConfigServers = loadServersFromNewList(config);
+  private void reconcileServers(VelocityConfiguration newConfiguration) {
+    List<ServerInfo> desired = new ArrayList<>();
+    for (Map.Entry<String, BackendServerConfig> entry : newConfiguration.getBackendServers().entrySet()) {
+      desired.add(new ServerInfo(entry.getKey(),
+          AddressUtil.parseAddress(entry.getValue().address()),
+          entry.getValue().forwardingMode()));
+    }
 
-    getAllServers().forEach(server -> {
-      if (!newConfigServers.contains(server.getServerInfo())) {
-        unregisterServer(server.getServerInfo());
+    // Servers registered now but absent from the new configuration: removed, renamed, or with a
+    // changed address/forwarding mode.
+    List<VelocityRegisteredServer> stale = new ArrayList<>();
+    for (VelocityRegisteredServer registered : getAllServers()) {
+      if (!desired.contains(registered.getServerInfo())) {
+        stale.add(registered);
       }
-    });
+    }
 
-    newConfigServers.forEach(serverInfo -> {
-      if (getServer(serverInfo.getName()).isEmpty()) {
-        registerServer(serverInfo);
+    Collection<ConnectedPlayer> evacuate = new ArrayList<>();
+    Set<ServerInfo> claimedRenames = new HashSet<>();
+    for (VelocityRegisteredServer old : stale) {
+      ServerInfo renameTarget = findRenameTarget(old.getServerInfo(), desired, claimedRenames);
+      if (renameTarget != null) {
+        // Pure rename: stand up the new server and move connected players onto it in place.
+        claimedRenames.add(renameTarget);
+        migratePlayers(old, registerServer(renameTarget));
+      } else {
+        // Removed or had its address/forwarding changed: evacuate the players to a fallback.
+        evacuate.addAll(old.getPlayersConnected());
       }
-    });
+      unregisterServer(old.getServerInfo());
+    }
+
+    // Register newly-added servers, plus any whose address/forwarding changed and whose old
+    // registration was just removed above.
+    for (ServerInfo info : desired) {
+      if (getServer(info.getName()).isEmpty()) {
+        registerServer(info);
+      }
+    }
+
+    evacuatePlayers(evacuate);
   }
 
-  /**
-   * Loads servers from the [servers] section of the configuration.
-   *
-   * @param config the Velocity configuration
-   * @return list of configured ServerInfo objects
-   */
-  private static List<ServerInfo> loadServersFromNewList(VelocityConfiguration config) {
-    List<ServerInfo> serverList = new ArrayList<>();
+  private @Nullable ServerInfo findRenameTarget(ServerInfo oldInfo, List<ServerInfo> desired, Set<ServerInfo> claimed) {
+    for (ServerInfo info : desired) {
+      if (claimed.contains(info) || info.getName().equalsIgnoreCase(oldInfo.getName())) {
+        continue;
+      }
+      if (getServer(info.getName()).isPresent()) {
+        continue;
+      }
+      if (info.getAddress().equals(oldInfo.getAddress())
+          && Objects.equals(info.getPlayerInfoForwardingMode(), oldInfo.getPlayerInfoForwardingMode())) {
+        return info;
+      }
+    }
+    return null;
+  }
 
-    config.getBackendServers().forEach((serverName, backendConfig) -> {
-      InetSocketAddress socketAddress = AddressUtil.parseAddress(backendConfig.address());
-      serverList.add(new ServerInfo(serverName, socketAddress, backendConfig.forwardingMode()));
-    });
+  private void migratePlayers(VelocityRegisteredServer from, VelocityRegisteredServer to) {
+    String fromName = from.getServerInfo().getName();
+    String toName = to.getServerInfo().getName();
 
-    return serverList;
+    Collection<ConnectedPlayer> players = from.getPlayersConnected();
+    if (players.isEmpty()) {
+      return;
+    }
+
+    CountDownLatch latch = new CountDownLatch(players.size());
+    for (ConnectedPlayer player : players) {
+      try {
+        player.getConnection().eventLoop().execute(() -> {
+          try {
+            VelocityServerConnection connected = player.getConnectedServer();
+            if (connected != null && connected.getServer() == from) {
+              from.removePlayer(player);
+              connected.migrateRegisteredServer(to);
+              to.addPlayer(player);
+
+              getClusterPlayerService().onPlayerSwitchServer(player, fromName, toName);
+            }
+
+            VelocityServerConnection inFlight = player.getConnectionInFlight();
+            if (inFlight != null && inFlight.getServer() == from) {
+              inFlight.migrateRegisteredServer(to);
+            }
+          } finally {
+            latch.countDown();
+          }
+        });
+      } catch (RejectedExecutionException e) {
+        latch.countDown();
+      }
+    }
+
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      LOGGER.error("Interrupted whilst migrating players to renamed server {}", toName, e);
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private void evacuatePlayers(Collection<ConnectedPlayer> evacuate) {
+    if (evacuate.isEmpty()) {
+      return;
+    }
+
+    CountDownLatch latch = new CountDownLatch(evacuate.size());
+    for (ConnectedPlayer player : evacuate) {
+      // Skip any fallback that resolves to the same backend the player is already connected to
+      // (e.g. a server that was renamed but kept its address).
+      InetSocketAddress currentAddress = player.getCurrentServer()
+          .map(conn -> conn.getServerInfo().getAddress())
+          .orElse(null);
+
+      var retrySession = player.currentServerRetrySession();
+      VelocityRegisteredServer target = null;
+      Optional<VelocityRegisteredServer> next;
+      while ((next = retrySession.getNextServerToTry()).isPresent()) {
+        if (currentAddress != null
+            && currentAddress.equals(next.get().getServerInfo().getAddress())) {
+          continue;
+        }
+        target = next.get();
+        break;
+      }
+
+      if (target != null) {
+        player.createConnectionRequest(target).connectWithIndication()
+            .whenComplete((success, ex) -> {
+              if (ex != null || success == null || !success) {
+                player.disconnect(Component.text(
+                    "Your server has been changed, but we could not move you to any fallback servers."));
+              }
+              latch.countDown();
+            });
+      } else {
+        latch.countDown();
+        player.disconnect(Component.text(
+            "Your server has been changed, but we could not move you to any fallback servers."));
+      }
+    }
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      LOGGER.error("Interrupted whilst moving players", e);
+      Thread.currentThread().interrupt();
+    }
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -63,7 +63,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class VelocityServerConnection implements MinecraftConnectionAssociation, ServerConnection {
 
-  private final VelocityRegisteredServer registeredServer;
+  private volatile VelocityRegisteredServer registeredServer;
 
   private final @Nullable VelocityRegisteredServer previousServer;
 
@@ -237,6 +237,16 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   @Override
   public VelocityRegisteredServer getServer() {
     return registeredServer;
+  }
+
+  /**
+   * Re-points this connection at a different {@link VelocityRegisteredServer} without reconnecting.
+   * Should only be used when a backend server is renamed during a configuration reload.
+   *
+   * @param registeredServer the server this connection should now be associated with
+   */
+  public void migrateRegisteredServer(VelocityRegisteredServer registeredServer) {
+    this.registeredServer = registeredServer;
   }
 
   @Override


### PR DESCRIPTION
Reimplement server reconcile logic during `/velocity reload` to fix broken logic (sends players to fallback servers on backend remove, migrates players' VelocityServerConnection to the new VelocityRegisteredServer on backend rename).

Our previous implementation was broken, and we also had upstream's reconcile logic still present (which is seemingly also broken, from testing on upstream only), but due to our own logic this was effectively a NOP.

This PR reimplements this logic and is redis-aware, and this PR also updates the queue manager to reconcile the queues on a server removal/addition.

New behavior when modifying backend server names in `velocity.toml`:
- on rename (same address, forwarding mode, etc) -> server unregister/register, 'migrate' all existing players by overriding the `VelocityRegisteredServer` to the new one in `VelocityServerConnection` (prevents stale references to an old/unregistered `VelocityRegisteredServer`
- on delete -> fallback the player following the fallback server chain, if a player cant be connected to any fallback server, disconnect them from the proxy. queue gets removed if present
- on add -> nothing to do other than registering the backend server, velocity already supports hot-server-additions. a queue gets created if enabled.

Fixes #962.