### PR TITLE
Update issue template branding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report issues with Velocity not working properly.
+description: Report issues with Velocity-CTD not working properly.
 labels: ["type: bug"]
 body:
   - type: textarea
@@ -19,7 +19,7 @@ body:
   - type: textarea
     attributes:
       label: Steps to Reproduce
-      description: Information on how we can reproduce this bug on our own, this can be e.g. just an explanation, a video or your Velocity config.
+      description: Information on how we can reproduce this bug on our own, this can be e.g. just an explanation, a video or your Velocity-CTD config.
     validations:
       required: true
 
@@ -28,13 +28,13 @@ body:
       label: Plugin List
       description: |
         All plugins running on your proxy and the backend server you're experiencing this issue on.
-        Use `/velocity plugins` to list plugins on Velocity and `/plugins` to list plugins on your backend server.
+        Use `/velocity plugins` to list plugins on Velocity-CTD and `/plugins` to list plugins on your backend server.
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: Velocity Version
+      label: Velocity-CTD Version
       description: |
         The full, unmodified output of running `/velocity info`.
         *"Latest"* is not a version. We require you to paste the text, not a screenshot.
@@ -42,9 +42,9 @@ body:
         <summary>Example</summary>
         
         ```
-        [17:44:10 INFO]: Velocity 3.4.0-SNAPSHOT (git-6e80f577-b534)  
-        [17:44:10 INFO]: Copyright 2018-2026 Velocity Contributors. Velocity is licensed under the terms of the GNU General Public License v3.  
-        [17:44:10 INFO]: PaperMC - GitHub  
+        [17:44:10 INFO]: Velocity-CTD 3.5.0-SNAPSHOT (git-1d1bfa7a-b313)  
+        [17:44:10 INFO]: Copyright 2018-2026 Velocity(-CTD) Contributors. Velocity-CTD is licensed under the terms of the GNU General Public License v3.  
+        [17:44:10 INFO]: discord.gg/beer - GitHub
         ```
         </details>
     validations:
@@ -62,8 +62,7 @@ body:
       value: |
         Before submitting this issue, please ensure the following:
 
-        1. You are running the latest version of Velocity from [our downloads page](https://papermc.io/downloads/velocity).
+        1. You are running the latest version of Velocity-CTD from [the releases tab](https://github.com/GemstoneGG/Velocity-CTD/releases/latest).
         2. You searched for and ensured there isn't already an open issue regarding this.
 
-        If you think you have a bug, but are not sure, feel free to ask in the `#velocity-help` channel on our
-        [Discord](https://discord.gg/papermc).
+        If you think you have a bug, but are not sure, feel free to ask on our [Discord](https://discord.gg/beer).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: PaperMC Discord
-    url: https://discord.gg/papermc
-    about: If you are having issues with the proxy not connecting to servers or have other minor issues, come ask us on our Discord server!
-  - name: Exploit Report
-    url: https://discord.gg/papermc
-    about: |
-      Due to GitHub not currently allowing private issues, exploit reports are currently handled via our Discord.
-      To report an exploit, see the #paper-exploit-report channel.
+  - name: RootBeer Discord
+    url: https://discord.gg/beer
+    about: If you are having issues with the proxy, found an exploit or have other minor issues, come ask us on our Discord server!

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,12 +1,12 @@
 name: Feature Request
-description: Request for a feature to be implemented into Velocity.
+description: Request for a feature to be implemented into Velocity-CTD.
 labels: ["type: feature"]
 body:
   - type: textarea
     attributes:
       label: Requested Feature
       description: |
-        Please describe as best as you can what you'd like to be added to Velocity.
+        Please describe as best as you can what you'd like to be added to Velocity-CTD.
     validations:
       required: true
 
@@ -40,9 +40,9 @@ body:
       value: |
         Before submitting this request, please ensure the following:
         
-        1. You are running the latest version of Velocity from [our downloads page](https://papermc.io/downloads/velocity).
+        1. You are running the latest version of Velocity-CTD from [the releases tab](https://github.com/GemstoneGG/Velocity-CTD/releases/latest).
         2. You searched for and ensured there isn't already an open issue regarding this.
-        3. The feature you're requesting has to be implemented on Velocity and not on the backend server.
+        3. The feature you're requesting has to be implemented on Velocity-CTD and not on the backend server or a proxy plugin.
         
-        If you are unsure whether your problem can already be fixed in another way, feel free to ask in the `#velocity-help` channel on our
-        [Discord](https://discord.gg/papermc).
+        If you are unsure whether your problem can already be fixed in another way, feel free to ask on our
+        [Discord](https://discord.gg/beer).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Velocity-CTD
 
-[![Join my Discord](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdG5sdGgwazRwYjh4djdsdXJwcHR5ajZrNGE2NDBvcTUzdXltbHp1cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fGIwpaCrtkFdHVksSu/giphy.gif)](https://discord.gg/beer) \
+[![Join the Discord](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdG5sdGgwazRwYjh4djdsdXJwcHR5ajZrNGE2NDBvcTUzdXltbHp1cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fGIwpaCrtkFdHVksSu/giphy.gif)](https://discord.gg/beer) \
 _[Discord](https://discord.gg/beer)_ | _[VelocityCTD.com](https://velocityctd.com/)_
 
 A Minecraft server proxy with unparalleled server support, scalability,


### PR DESCRIPTION
Updates GitHub issue templates to Velocity-CTD branding, including pointing them to the RootBeer discord. Also allows everyone to open blank issues - we don't get many issues so I think this is fine, if we ever start getting more, we might want to toggle this off again.