### PR TITLE
Confirm whether the player is actually online on another proxy before aborting the join

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/redis/data/VelocityVerifyPlayer.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/data/VelocityVerifyPlayer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Velocity-CTD Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocityctd.proxy.redis.data;
+
+import com.velocityctd.proxy.redis.transaction.TransactionData;
+import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Data record representing a request asking the proxy identified by {@code proxyId} whether it
+ * still has the given player connected.
+ *
+ * @param uniqueId the player's unique ID
+ * @param proxyId  the id of the proxy the entry claims the player is connected to
+ */
+public record VelocityVerifyPlayer(UUID uniqueId, String proxyId) implements TransactionData<Boolean> {
+
+  @Override
+  public @NotNull Class<Boolean> responseClass() {
+    return Boolean.class;
+  }
+}

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/depot/player/PlayerDepotService.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/depot/player/PlayerDepotService.java
@@ -19,6 +19,7 @@ package com.velocityctd.proxy.redis.depot.player;
 
 import com.velocityctd.proxy.redis.VelocityRedis;
 import com.velocityctd.proxy.redis.data.VelocityKick;
+import com.velocityctd.proxy.redis.data.VelocityVerifyPlayer;
 import com.velocityctd.proxy.redis.depot.AbstractDepotService;
 import com.velocitypowered.api.proxy.player.PlayerSettings;
 import com.velocitypowered.api.scheduler.ScheduledTask;
@@ -28,7 +29,12 @@ import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import net.kyori.adventure.text.Component;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
@@ -38,6 +44,15 @@ import org.jetbrains.annotations.Unmodifiable;
  * functionality to track certain information about a single player, or multiple players.
  */
 public final class PlayerDepotService extends AbstractDepotService<UUID, PlayerEntry> {
+
+  private static final Logger LOGGER = LogManager.getLogger(PlayerDepotService.class);
+
+  /**
+   * How long to wait for the owning proxy to confirm a player is still connected before treating
+   * an existing depot entry as stale. Only applies on connect when a player appears to already be
+   * online on another proxy.
+   */
+  private static final Duration LIVENESS_TIMEOUT = Duration.ofMillis(800L);
 
   /**
    * The Redis manager used to coordinate multi-proxy player synchronization.
@@ -124,14 +139,45 @@ public final class PlayerDepotService extends AbstractDepotService<UUID, PlayerE
           this.redis.publish(new VelocityKick(player.getUniqueId(), component, existingEntry.getProxyId()));
         }
       } else {
-        Component component = Component.translatable("velocity.error.already-connected-proxy.remote");
-        player.disconnect0(component, true);
-        return false;
+        PlayerEntry existingEntry = this.depot.get(player.getUniqueId());
+        if (existingEntry != null && isPlayerActuallyOnline(player.getUniqueId(), existingEntry)) {
+          Component component = Component.translatable("velocity.error.already-connected-proxy.remote");
+          player.disconnect0(component, true);
+          return false;
+        }
+
+        // Delete stale entry
+        this.depot.remove(player.getUniqueId());
       }
     }
 
     this.upsertPlayerEntry(player);
     return true;
+  }
+
+  /**
+   * Returns whether the player behind an existing depot entry is genuinely still connected, as
+   * opposed to the entry being stale.
+   */
+  private boolean isPlayerActuallyOnline(UUID uniqueId, @NotNull PlayerEntry entry) {
+    if (entry.getProxyId().equalsIgnoreCase(this.redis.getProxyId())) {
+      return this.server.getPlayer(uniqueId).isPresent();
+    }
+
+    try {
+      Boolean online = this.redis.publishTransaction(new VelocityVerifyPlayer(uniqueId, entry.getProxyId()))
+              .get(LIVENESS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+      return Boolean.TRUE.equals(online);
+    } catch (TimeoutException e) {
+      return false;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return true;
+    } catch (ExecutionException e) {
+      LOGGER.warn("Failed to verify whether {} is still connected to proxy {}.",
+              uniqueId, entry.getProxyId(), e);
+      return true;
+    }
   }
 
   /**

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/handler/TransactionHandlerRegistry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/handler/TransactionHandlerRegistry.java
@@ -23,6 +23,7 @@ import com.velocityctd.proxy.redis.data.VelocityGetPlayerPing;
 import com.velocityctd.proxy.redis.data.VelocityReload;
 import com.velocityctd.proxy.redis.data.VelocityTransferRemote;
 import com.velocityctd.proxy.redis.data.VelocityUptime;
+import com.velocityctd.proxy.redis.data.VelocityVerifyPlayer;
 import com.velocityctd.proxy.redis.transaction.TransactionData;
 import com.velocityctd.proxy.redis.transaction.TransactionHandler;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -109,6 +110,18 @@ public enum TransactionHandlerRegistry {
     }).delay(100, TimeUnit.MILLISECONDS).schedule();
 
     return fut;
+  }),
+
+  /**
+   * Handles the {@link VelocityVerifyPlayer} transaction by replying with whether the targeted
+   * proxy still has the given player connected.
+   */
+  VELOCITY_VERIFY_PLAYER(VelocityVerifyPlayer.class, (server, data) -> {
+    if (!data.proxyId().equalsIgnoreCase(server.getProxyId())) {
+      return null;
+    }
+
+    return completedFuture(server.getPlayer(data.uniqueId()).isPresent());
   }),
   ;
 


### PR DESCRIPTION
Confirm whether the player is actually online on another proxy before aborting the join instead of relying on the player entry reap period (5 seconds).

Attempts to resolve #972.