### PR TITLE
Fix redis presence before DisconnectEvent cleanup

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/redis/depot/player/PlayerDepotService.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/depot/player/PlayerDepotService.java
@@ -311,6 +311,10 @@ public final class PlayerDepotService extends AbstractDepotService<UUID, PlayerE
     }
 
     for (ConnectedPlayer player : this.server.getOnlinePlayers()) {
+      if (player.getConnection().isClosed()) {
+        continue;
+      }
+
       if (this.depot.contains(player.getUniqueId())) {
         continue;
       }
@@ -323,7 +327,8 @@ public final class PlayerDepotService extends AbstractDepotService<UUID, PlayerE
         continue;
       }
 
-      if (this.server.getPlayer(playerEntry.getUniqueId()).isPresent()) {
+      ConnectedPlayer player = this.server.getPlayer(playerEntry.getUniqueId()).orElse(null);
+      if (player != null && !player.getConnection().isClosed()) {
         continue;
       }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1488,6 +1488,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       connectedServer.disconnect();
     }
 
+    if (this.fullyConnected) {
+      this.server.getClusterPlayerService().onPlayerDisconnect(this);
+    }
+
     server.getPlayerRegistry().unregisterConnection(this);
   }
 


### PR DESCRIPTION
Remove a player's Redis presence entry when their connection closes instead of after DisconnectEvent cleanup, and make the depot sync/reaper liveness-based so a slow disconnect handler can't keep a stale entry alive. Fixes #972