### PR TITLE
Add offline-mode encryption (Replaces OfflineEncryptor, fix NLogin compatibility)

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -59,6 +59,12 @@ public class CtdConfigMigrations {
             true
         ),
         migration(
+            "If true, offline-mode connections still use the vanilla encryption handshake without Mojang auth."
+                + " Only works on Minecraft 1.20.5+ clients.",
+            "offline-mode-encryption",
+            false
+        ),
+        migration(
             "Should tell client that proxy doesn't report chat messages? (useful for NoChatReports mod).",
             "prevents-chat-reports",
             false

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -92,6 +92,9 @@ public final class VelocityConfiguration implements ProxyConfig {
   private final boolean onlineMode;
 
   @Expose
+  private final boolean offlineModeEncryption;
+
+  @Expose
   private final boolean preventClientProxyConnections;
 
   @Expose
@@ -250,6 +253,7 @@ public final class VelocityConfiguration implements ProxyConfig {
 
   private VelocityConfiguration(String bind, List<String> motd, List<String> motdHover,
                                 int showMaxPlayers, boolean onlineMode,
+                                boolean offlineModeEncryption,
                                 boolean preventClientProxyConnections, boolean announceForge,
                                 PlayerInfoForwarding playerInfoForwardingMode, byte[] forwardingSecret,
                                 boolean kickExistingPlayers, boolean kickExistingPlayersCheckIp,
@@ -274,6 +278,7 @@ public final class VelocityConfiguration implements ProxyConfig {
     this.motdHover = motdHover;
     this.showMaxPlayers = showMaxPlayers;
     this.onlineMode = onlineMode;
+    this.offlineModeEncryption = offlineModeEncryption;
     this.preventClientProxyConnections = preventClientProxyConnections;
     this.announceForge = announceForge;
     this.playerInfoForwardingMode = playerInfoForwardingMode;
@@ -518,6 +523,10 @@ public final class VelocityConfiguration implements ProxyConfig {
   @Override
   public boolean isOnlineMode() {
     return onlineMode;
+  }
+
+  public boolean isOfflineModeEncryptionEnabled() {
+    return offlineModeEncryption;
   }
 
   @Override
@@ -1015,6 +1024,7 @@ public final class VelocityConfiguration implements ProxyConfig {
         .add("motdHover", motdHover)
         .add("showMaxPlayers", showMaxPlayers)
         .add("onlineMode", onlineMode)
+        .add("offlineModeEncryption", offlineModeEncryption)
         .add("preventClientProxyConnections", preventClientProxyConnections)
         .add("playerInfoForwardingMode", playerInfoForwardingMode)
         .add("announceForge", announceForge)
@@ -1168,6 +1178,7 @@ public final class VelocityConfiguration implements ProxyConfig {
       String bind = config.getOrElse("bind", "0.0.0.0:25565");
       int maxPlayers = config.getIntOrElse("show-max-players", 500);
       boolean onlineMode = config.getOrElse("online-mode", true);
+      boolean offlineModeEncryption = config.getOrElse("offline-mode-encryption", false);
       boolean forceKeyAuthentication = config.getOrElse("force-key-authentication", true);
       boolean announceForge = config.getOrElse("announce-forge", true);
       boolean preventClientProxyConnections = config.getOrElse("prevent-client-proxy-connections", false);
@@ -1267,6 +1278,7 @@ public final class VelocityConfiguration implements ProxyConfig {
           motdHover,
           maxPlayers,
           onlineMode,
+          offlineModeEncryption,
           preventClientProxyConnections,
           announceForge,
           forwardingMode,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -87,6 +87,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
   private byte[] verify = EMPTY_BYTE_ARRAY;
 
+  private boolean authenticateWithMojang;
+
   private LoginState currentState = LoginState.LOGIN_PACKET_EXPECTED;
 
   private final boolean forceKeyAuthentication;
@@ -168,10 +170,16 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
         }
 
         mcConnection.eventLoop().execute(() -> {
-          if (!result.isForceOfflineMode()
-              && (server.getConfiguration().isOnlineMode() || result.isOnlineModeAllowed())) {
+          boolean onlineAuth = !result.isForceOfflineMode()
+              && (server.getConfiguration().isOnlineMode() || result.isOnlineModeAllowed());
+          boolean offlineEncryption = !onlineAuth
+              && server.getConfiguration().isOfflineModeEncryptionEnabled()
+              && mcConnection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_5);
+
+          if (onlineAuth || offlineEncryption) {
             // Request encryption.
-            EncryptionRequestPacket request = generateEncryptionRequest();
+            EncryptionRequestPacket request = generateEncryptionRequest(onlineAuth);
+            this.authenticateWithMojang = onlineAuth;
             this.verify = Arrays.copyOf(request.getVerifyToken(), 4);
             mcConnection.write(request);
             this.currentState = LoginState.ENCRYPTION_REQUEST_SENT;
@@ -229,6 +237,13 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
       // Go ahead and enable encryption. Once the client sends EncryptionResponse, encryption
       // is enabled.
       mcConnection.enableEncryption(decryptedSharedSecret);
+
+      if (!authenticateWithMojang) {
+        mcConnection.setActiveSessionHandler(StateRegistry.LOGIN,
+            new AuthSessionHandler(server, inbound,
+                GameProfile.forOfflinePlayer(login.getUsername()), false, null, appliedResourcePacksFuture));
+        return true;
+      }
 
       String serverId = generateServerId(decryptedSharedSecret, serverKeyPair.getPublic());
       String playerIp = ((InetSocketAddress) mcConnection.getRemoteAddress()).getHostString();
@@ -298,13 +313,14 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
     return false;
   }
 
-  private EncryptionRequestPacket generateEncryptionRequest() {
+  private EncryptionRequestPacket generateEncryptionRequest(boolean shouldAuthenticate) {
     byte[] verify = new byte[4];
     SECURE_RANDOM.nextBytes(verify);
 
     EncryptionRequestPacket request = new EncryptionRequestPacket();
     request.setPublicKey(server.getServerKeyPair().getPublic().getEncoded());
     request.setVerifyToken(verify);
+    request.setShouldAuthenticate(shouldAuthenticate);
     return request;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/EncryptionRequestPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/EncryptionRequestPacket.java
@@ -52,6 +52,10 @@ public class EncryptionRequestPacket implements MinecraftPacket {
     this.verifyToken = verifyToken.clone();
   }
 
+  public void setShouldAuthenticate(boolean shouldAuthenticate) {
+    this.shouldAuthenticate = shouldAuthenticate;
+  }
+
   @Override
   public String toString() {
     return "EncryptionRequest{"

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -41,6 +41,10 @@ show-max-players = 500
 # Should we authenticate players with Mojang? By default, this is on.
 online-mode = true
 
+# If true, offline-mode connections still use the vanilla encryption handshake without Mojang auth.
+# Only works on Minecraft 1.20.5+ clients.
+offline-mode-encryption = false
+
 # Whether chat signing should be enforced. If disabled, backend servers MUST disable chat signing.
 enforce-chat-signing = true
 


### PR DESCRIPTION
I discovered a strange incompatibility with NLogin i suddenly found out, even for upstream Velocity.

Apparently, NLogin proceed to just enable online auth in offline mode anyway, but when forcefully strip it, it will yell for encryption.

Such this one done properly, by just adding the encryption when offline. This should add setup conveniency and overall security. It shouldn't interfere with base behaviour, though some plugin might demands it. It is though considerable because it has some potential to conflict with plugins that has premium detection, which I doesn't have one.

### Reference:
- [Offline Encryptor on Modrinth](https://modrinth.com/plugin/offlineencryptor)

### After patch tested behaviour:
- Premium on Online: ok
- Premium on Offline Encrypted: ok
- Cracked on Offline Encrypted: ok
- Cracked on Offline Encryptless: ok
- 1.20.1 on Offline Encrypted: ok
- 1.20.1 on Offline Encryptless: ok