### PR TITLE
Advance the backend to PLAY during configuration resource-pack holds …

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -510,6 +510,27 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     }
   }
 
+  /**
+   * Buffers inbound PLAY packets (letting CONFIG packets such as keepalives through) until {@link
+   * #removePlayPacketQueueInboundHandler()} drains them.
+   */
+  public void addPlayPacketQueueInboundHandler() {
+    if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_INBOUND) == null) {
+      this.channel.pipeline().addAfter(Connections.MINECRAFT_DECODER, Connections.PLAY_PACKET_QUEUE_INBOUND,
+           new PlayPacketQueueInboundHandler(this.protocolVersion,
+               channel.pipeline().get(MinecraftDecoder.class).getDirection(), false));
+    }
+  }
+
+  /**
+   * Removes the inbound play packet queue handler, draining buffered packets back into the pipeline.
+   */
+  public void removePlayPacketQueueInboundHandler() {
+    if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_INBOUND) != null) {
+      this.channel.pipeline().remove(Connections.PLAY_PACKET_QUEUE_INBOUND);
+    }
+  }
+
   public ProtocolVersion getProtocolVersion() {
     return protocolVersion;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -164,6 +164,13 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(KeepAlivePacket packet) {
+    // Backend advanced to PLAY early while the client is still held in config: echo the keepalive
+    // back to keep the backend alive instead of forwarding it to the still-configuring client.
+    if (serverConn.getPlayer().getConnection().getState() == StateRegistry.CONFIG) {
+      serverConn.ensureConnected().write(packet);
+      return true;
+    }
+
     serverConn.getPendingPings().put(packet.getRandomId(), System.nanoTime());
     return false; // forwards on
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -83,8 +83,10 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
   private static final Logger LOGGER = LogManager.getLogger(ConfigSessionHandler.class);
 
   // Advance the backend to PLAY this long after it finishes configuring, decoupling it from a client
-  // still held in config (e.g. applying a resource pack) before the backend times out.
-  private static final long SPLIT_PHASE_DELAY_SECONDS = 9L;
+  // still held in config (e.g. applying a resource pack) before the backend times out. When 0 or
+  // less, advance immediately without ever holding the backend in config.
+  private static final long SPLIT_PHASE_DELAY_SECONDS =
+      Long.getLong("velocity-ctd.split-phase-delay-seconds", 9L);
 
   private final VelocityServer server;
 
@@ -264,12 +266,20 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
     CompletableFuture<Void> clientFinished = configHandler.handleBackendFinishUpdate(serverConn);
 
     // Advance the backend to PLAY on whichever comes first: the client finishing, or the timeout.
-    // If the timeout wins, buffer the backend's PLAY packets until the client catches up.
-    ScheduledFuture<?> splitTask = smc.eventLoop().schedule(
-        () -> advanceBackendToPlay(true), SPLIT_PHASE_DELAY_SECONDS, TimeUnit.SECONDS);
+    // If the timeout wins, buffer the backend's PLAY packets until the client catches up. A delay of
+    // 0 or less advances immediately, buffering from the start without holding the backend in config.
+    final ScheduledFuture<?> splitTask = SPLIT_PHASE_DELAY_SECONDS > 0
+        ? smc.eventLoop().schedule(
+            () -> advanceBackendToPlay(true), SPLIT_PHASE_DELAY_SECONDS, TimeUnit.SECONDS)
+        : null;
+    if (splitTask == null) {
+      advanceBackendToPlay(true);
+    }
 
     clientFinished.thenRunAsync(() -> {
-      splitTask.cancel(false);
+      if (splitTask != null) {
+        splitTask.cancel(false);
+      }
       // Client won the race: advance now (already in PLAY, no buffering) and drain anything the
       // timeout may have buffered.
       advanceBackendToPlay(false);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -37,6 +37,7 @@ import com.velocitypowered.proxy.connection.player.resourcepack.handler.Resource
 import com.velocitypowered.proxy.connection.util.ConnectionMessages;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
+import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
@@ -61,11 +62,12 @@ import com.velocitypowered.proxy.protocol.util.PluginMessageUtil;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,6 +82,10 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   private static final Logger LOGGER = LogManager.getLogger(ConfigSessionHandler.class);
 
+  // Advance the backend to PLAY this long after it finishes configuring, decoupling it from a client
+  // still held in config (e.g. applying a resource pack) before the backend times out.
+  private static final long SPLIT_PHASE_DELAY_SECONDS = 9L;
+
   private final VelocityServer server;
 
   private final VelocityServerConnection serverConn;
@@ -89,6 +95,9 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
   private ResourcePackInfo resourcePackToApply;
 
   private final State state;
+
+  // Guards advanceBackendToPlay; only touched on the backend event loop.
+  private boolean backendAdvancedToPlay;
 
   /**
    * Creates the new transition handler.
@@ -249,27 +258,31 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
     smc.getChannel().pipeline().get(MinecraftVarintFrameDecoder.class).setState(StateRegistry.PLAY);
     smc.getChannel().pipeline().get(MinecraftDecoder.class).setState(StateRegistry.PLAY);
-    // noinspection DataFlowIssue
-    configHandler.handleBackendFinishUpdate(serverConn).thenRunAsync(() -> {
-      smc.write(FinishedUpdatePacket.INSTANCE);
-      if (serverConn == player.getConnectedServer()) {
-        smc.setActiveSessionHandler(StateRegistry.PLAY);
-        player.sendPlayerListHeaderAndFooter(player.getPlayerListHeader(), player.getPlayerListFooter());
-        // The client cleared the tab list. TODO: Restore changes done via TabList API
-        player.getTabList().clearAllSilent();
-      } else {
-        smc.setActiveSessionHandler(StateRegistry.PLAY, new TransitionSessionHandler(server, serverConn, resultFuture));
-      }
 
-      if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21)) {
-        String target = serverConn.getServerInfo().getName();
-        player.setServerLinks(server.getConfiguration().getServerLinksFor(target));
-      }
+    // Start client-side configuration; may hold the player to apply a resource pack.
+    // noinspection DataFlowIssue
+    CompletableFuture<Void> clientFinished = configHandler.handleBackendFinishUpdate(serverConn);
+
+    // Advance the backend to PLAY on whichever comes first: the client finishing, or the timeout.
+    // If the timeout wins, buffer the backend's PLAY packets until the client catches up.
+    ScheduledFuture<?> splitTask = smc.eventLoop().schedule(
+        () -> advanceBackendToPlay(true), SPLIT_PHASE_DELAY_SECONDS, TimeUnit.SECONDS);
+
+    clientFinished.thenRunAsync(() -> {
+      splitTask.cancel(false);
+      // Client won the race: advance now (already in PLAY, no buffering) and drain anything the
+      // timeout may have buffered.
+      advanceBackendToPlay(false);
+      smc.removePlayPacketQueueInboundHandler();
 
       if (player.resourcePackHandler().getFirstAppliedPack() == null && resourcePackToApply != null) {
         player.resourcePackHandler().queueResourcePack(resourcePackToApply);
       }
-    }, smc.eventLoop());
+    }, smc.eventLoop()).exceptionally(ex -> {
+      LOGGER.error("Error advancing backend {} to play for {}",
+          serverConn.getServerInfo().getName(), player.getUsername(), ex);
+      return null;
+    });
     return true;
   }
 
@@ -398,14 +411,51 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
     return true;
   }
 
-  @Override
-  public void disconnected() {
+  /**
+   * Acknowledges the backend and advances it to PLAY, decoupled from the client. Runs at most once.
+   *
+   * @param buffer whether to buffer the backend's inbound PLAY packets until the client enters PLAY
+   */
+  private void advanceBackendToPlay(boolean buffer) {
+    MinecraftConnection smc = serverConn.getConnection();
+    if (backendAdvancedToPlay || smc == null || smc.isClosed()) {
+      return;
+    }
+    backendAdvancedToPlay = true;
+
     ConnectedPlayer player = serverConn.getPlayer();
-    if (player.getConnection().getActiveSessionHandler() instanceof ClientConfigSessionHandler configHandler
-        && configHandler.isAwaitingConfigurationResourcePack()) {
-      player.disconnect(Component.translatable("velocity.error.resource-pack-configuration-timeout", NamedTextColor.RED));
+
+    smc.write(FinishedUpdatePacket.INSTANCE);
+    if (serverConn == player.getConnectedServer()) {
+      smc.setActiveSessionHandler(StateRegistry.PLAY);
+      player.sendPlayerListHeaderAndFooter(player.getPlayerListHeader(), player.getPlayerListFooter());
+      // The client cleared the tab list. TODO: Restore changes done via TabList API
+      player.getTabList().clearAllSilent();
+    } else {
+      smc.setActiveSessionHandler(StateRegistry.PLAY, new TransitionSessionHandler(server, serverConn, resultFuture));
     }
 
+    if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21)) {
+      String target = serverConn.getServerInfo().getName();
+      player.setServerLinks(server.getConfiguration().getServerLinksFor(target));
+    }
+
+    // Must follow setActiveSessionHandler: switching to PLAY strips any inbound queue handler.
+    if (buffer) {
+      smc.addPlayPacketQueueInboundHandler();
+
+      // Swap the short login read-timeout for the in-play one now; otherwise a quiet backend could
+      // be dropped before the deferred JoinGame processing does the swap.
+      final var backendPipeline = smc.getChannel().pipeline();
+      if (backendPipeline.context(Connections.READ_TIMEOUT) != null) {
+        backendPipeline.replace(Connections.READ_TIMEOUT, Connections.READ_TIMEOUT,
+            new ReadTimeoutHandler(server.getConfiguration().getReadTimeout(), TimeUnit.MILLISECONDS));
+      }
+    }
+  }
+
+  @Override
+  public void disconnected() {
     resultFuture.complete(ConnectionRequestResults.forDisconnect(
         ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR, serverConn.getServer()));
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -34,6 +34,7 @@ import com.velocitypowered.proxy.connection.util.ConnectionMessages;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
 import com.velocitypowered.proxy.network.Connections;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
@@ -41,6 +42,9 @@ import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.util.ReferenceCountUtil;
+import java.util.ArrayDeque;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -60,6 +64,11 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
   private final CompletableFuture<Impl> resultFuture;
 
   private final BungeeCordMessageResponder bungeecordMessageResponder;
+
+  // Backend packets arriving while JoinGame is processed (async) are held and replayed after it, so
+  // the client never gets world data before JoinGame. Empty in the normal flow (autoReading off).
+  private boolean joinGameProcessing;
+  private final Queue<MinecraftPacket> deferredPackets = new ArrayDeque<>();
 
   /**
    * Creates the new transition handler.
@@ -96,6 +105,9 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(JoinGamePacket packet) {
+    // Hold packets that follow JoinGame until it's processed, then replay in order.
+    this.joinGameProcessing = true;
+
     final MinecraftConnection smc = serverConn.ensureConnected();
     final VelocityRegisteredServer previousServer = serverConn.getPreviousServer().orElse(null);
     final ConnectedPlayer player = serverConn.getPlayer();
@@ -155,6 +167,9 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
           // Now set the connected server.
           serverConn.getPlayer().setConnectedServer(serverConn);
 
+          // JoinGame processed: replay any packets held behind it before resuming reads.
+          flushDeferredPackets();
+
           // Clean up disabling auto-read while the connected event was being processed.
           // Do this after setting the connection, so no incoming packets are processed before
           // the API knows which server the player is connected to.
@@ -184,6 +199,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
           LOGGER.error("Unable to switch to new server {} for {}",
               serverConn.getServerInfo().getName(),
               player.getUsername(), exc);
+          releaseDeferredPackets();
           player.disconnect(ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR);
           resultFuture.completeExceptionally(exc);
           return null;
@@ -210,6 +226,13 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(PluginMessagePacket packet) {
+    // Hold plugin messages during JoinGame processing so they reach the client after it.
+    if (joinGameProcessing) {
+      ReferenceCountUtil.retain(packet);
+      deferredPackets.add(packet);
+      return true;
+    }
+
     if (bungeecordMessageResponder.process(packet)) {
       return true;
     }
@@ -236,7 +259,39 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
   }
 
   @Override
+  public void handleGeneric(MinecraftPacket packet) {
+    // Hold packets during JoinGame processing to replay in order; otherwise drop (the default).
+    if (joinGameProcessing) {
+      ReferenceCountUtil.retain(packet);
+      deferredPackets.add(packet);
+    }
+  }
+
+  private void flushDeferredPackets() {
+    joinGameProcessing = false;
+    if (deferredPackets.isEmpty()) {
+      return;
+    }
+
+    final MinecraftConnection clientConn = serverConn.getPlayer().getConnection();
+    MinecraftPacket packet;
+    while ((packet = deferredPackets.poll()) != null) {
+      clientConn.delayedWrite(packet);
+    }
+    clientConn.flush();
+  }
+
+  private void releaseDeferredPackets() {
+    joinGameProcessing = false;
+    MinecraftPacket packet;
+    while ((packet = deferredPackets.poll()) != null) {
+      ReferenceCountUtil.release(packet);
+    }
+  }
+
+  @Override
   public void disconnected() {
+    releaseDeferredPackets();
     resultFuture.complete(ConnectionRequestResults.forDisconnect(
         ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR, serverConn.getServer()));
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -74,9 +74,10 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   // while holding it to apply a pack.
   private static final long RESOURCE_PACK_KEEP_ALIVE_INTERVAL_SECONDS = 1L;
 
-  // Advance an unsettled optional pack to PLAY before the backend's ~15s config timeout. Kept below
-  // that budget minus the following PlayerFinishConfigurationEvent (up to 5s) and the client ack.
-  private static final long OPTIONAL_RESOURCE_PACK_HOLD_TIMEOUT_SECONDS = 9L;
+  // Disconnect an unresponsive client after this long, so it can't hold the decoupled backend (and
+  // its growing packet buffer) open forever. A flat deadline, not reset by progress, so keep it
+  // generous for slow large-pack downloads.
+  private static final long RESOURCE_PACK_HOLD_CAP_SECONDS = 180L;
 
   private final VelocityServer server;
 
@@ -395,9 +396,9 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
 
   /**
    * Fires the {@link PlayerConfigurationResourcePackEvent} and, if a pack was set, holds the player
-   * in configuration until it settles. A {@link ResourcePackRequest#required() required} pack is
-   * held indefinitely until the client acks; an optional pack is held only until
-   * {@link #OPTIONAL_RESOURCE_PACK_HOLD_TIMEOUT_SECONDS}, then advances to play as if declined.
+   * in configuration until every pack settles, or disconnects after
+   * {@link #RESOURCE_PACK_HOLD_CAP_SECONDS}. The backend is advanced to PLAY separately (see
+   * {@code ConfigSessionHandler}) so it doesn't time out during the hold.
    *
    * @param serverConn the server (re-)configuring the player
    * @param firstJoin  whether this is the initial configuration following login
@@ -417,11 +418,16 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
       this.resourcePackHold = hold;
       startResourcePackKeepAlive();
 
-      CompletableFuture<Void> gate = request.required()
-          ? hold
-          : hold.completeOnTimeout(null, OPTIONAL_RESOURCE_PACK_HOLD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      // Disconnect a player who never responds within the cap.
+      ScheduledFuture<?> holdCap = player.getConnection().eventLoop().schedule(() -> {
+        if (!hold.isDone()) {
+          player.disconnect(Component.translatable(
+              "velocity.error.resource-pack-configuration-timeout", NamedTextColor.RED));
+        }
+      }, RESOURCE_PACK_HOLD_CAP_SECONDS, TimeUnit.SECONDS);
 
-      return gate.whenCompleteAsync((v, t) -> {
+      return hold.whenCompleteAsync((v, t) -> {
+        holdCap.cancel(false);
         stopResourcePackKeepAlive();
         this.resourcePackHold = null;
       }, player.getConnection().eventLoop()).exceptionally(t -> {
@@ -431,16 +437,10 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
     }, player.getConnection().eventLoop());
   }
 
-  public boolean isAwaitingConfigurationResourcePack() {
-    return resourcePackHold != null;
-  }
-
   private void startResourcePackKeepAlive() {
     if (resourcePackKeepAlive == null) {
       resourcePackKeepAlive = player.getConnection().eventLoop().scheduleAtFixedRate(
-          () -> {
-            player.sendKeepAlive();
-          },
+          player::sendKeepAlive,
           RESOURCE_PACK_KEEP_ALIVE_INTERVAL_SECONDS,
           RESOURCE_PACK_KEEP_ALIVE_INTERVAL_SECONDS,
           TimeUnit.SECONDS);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -77,7 +77,8 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   // Disconnect an unresponsive client after this long, so it can't hold the decoupled backend (and
   // its growing packet buffer) open forever. A flat deadline, not reset by progress, so keep it
   // generous for slow large-pack downloads.
-  private static final long RESOURCE_PACK_HOLD_CAP_SECONDS = 180L;
+  private static final long RESOURCE_PACK_HOLD_CAP_SECONDS =
+      Long.getLong("velocity-ctd.resource-pack-hold-cap-seconds", 60L);
 
   private final VelocityServer server;
 


### PR DESCRIPTION
`PlayerConfigurationResourcePackEvent` (#992) holds the player in the configuration state until every pack settles. In practice, slow clients and clients with large pre-applied packs take longer than the backend will wait for its config to be acknowledged, so the backend times out and the player is kicked, making the feature unusable for its main use case.

This PR decouples the backend from the client-side hold. Once the backend finishes configuring, it's acknowledged and advanced to `PLAY` (after a 9s grace period if the client is still applying a pack), while its `PLAY` packets (`JoinGame`, world data, etc.) are buffered until the client catches up, and its keepalives are echoed back to keep it alive. The player can now sit in configuration essentially indefinitely without the backend dropping, with a 3-minute hold cap that disconnects unresponsive clients cleanly instead of letting the packet buffer grow unbounded.