### PR TITLE
Skip reconfig when possible

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerBackendConfigurationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerBackendConfigurationEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player.configuration;
+
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is executed when Velocity starts the backend server's configuration state for a player.
+ *
+ * <p>Velocity will wait for this event before processing backend configuration packets.</p>
+ *
+ * @param player The player whose backend connection is being configured.
+ * @param server The backend server currently configuring the connection.
+ * @since Minecraft 1.20.2
+ */
+@AwaitingEvent
+public record PlayerBackendConfigurationEvent(@NotNull Player player, ServerConnection server) {
+}

--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -214,6 +214,13 @@ public class CtdConfigMigrations {
             "advanced.pool-players-across-sections",
             false
         ),
+        migration(
+            "When a 1.20.2+ player switches backends and the registries are compatible, skip the\n"
+                + " client-visible configuration phase and complete the switch entirely in the PLAY state,\n"
+                + " which avoids the reconfiguration flicker. Falls back to a normal switch when incompatible.",
+            "advanced.fast-server-switch",
+            false
+        ),
 
         // [redis]
         migration(

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
@@ -21,7 +21,10 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -29,12 +32,24 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.CRC32;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class ConfigStateSnapshot {
+
+  private static final Logger LOGGER = LogManager.getLogger(ConfigStateSnapshot.class);
+
+  /**
+   * When set to a directory path, every registry-sync / tags payload fed into a labelled builder is
+   * written there as {@code <dumpDir>/<label>/NN-<tag>-<name>.bin}, for byte-level diffing of what
+   * each backend sends during configuration. Debug-only; unset in normal operation.
+   */
+  private static final @Nullable String DUMP_DIR = System.getProperty("velocityctd.fasttransition.dumpDir");
 
   private static final Set<String> IGNORED_REGISTRIES = Set.of(
       "minecraft:chat_type",
@@ -65,16 +80,31 @@ public final class ConfigStateSnapshot {
     return entries;
   }
 
+  public String fingerprintHex() {
+    return ByteBufUtil.hexDump(fingerprint);
+  }
+
   public static Builder builder() {
-    return new Builder();
+    return new Builder(null);
+  }
+
+  /**
+   * Creates a builder that, when {@code -Dvelocityctd.fasttransition.dumpDir=...} is set, also writes
+   * each captured payload to disk under the given label (e.g. the backend server name).
+   */
+  public static Builder builder(@Nullable String dumpLabel) {
+    return new Builder(dumpLabel);
   }
 
   public static final class Builder {
 
     private final Map<String, byte[]> registryData = new LinkedHashMap<>();
     private byte @Nullable [] tagsData;
+    private final @Nullable String dumpLabel;
+    private int seq;
 
-    private Builder() {
+    private Builder(@Nullable String dumpLabel) {
+      this.dumpLabel = dumpLabel;
     }
 
     /**
@@ -85,6 +115,7 @@ public final class ConfigStateSnapshot {
       byte[] data = ByteBufUtil.getBytes(content);
       String name = peekRegistryName(content);
       registryData.put(name, data);
+      dumpPayload((byte) 'R', name, data);
     }
 
     public void addTags(Map<String, Map<String, int[]>> tags) {
@@ -110,8 +141,24 @@ public final class ConfigStateSnapshot {
           }
         }
         tagsData = ByteBufUtil.getBytes(buf);
+        dumpPayload((byte) 'T', "tags", tagsData);
       } finally {
         buf.release();
+      }
+    }
+
+    private void dumpPayload(byte tag, String name, byte[] data) {
+      if (DUMP_DIR == null || dumpLabel == null) {
+        return;
+      }
+      String safeName = name.replaceAll("[^a-zA-Z0-9._-]", "_");
+      String file = String.format(Locale.ROOT, "%02d-%c-%s.bin", seq++, (char) tag, safeName);
+      try {
+        Path dir = Path.of(DUMP_DIR, dumpLabel);
+        Files.createDirectories(dir);
+        Files.write(dir.resolve(file), data);
+      } catch (IOException e) {
+        LOGGER.warn("Failed to dump config payload {} for label {}", file, dumpLabel, e);
       }
     }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
@@ -17,6 +17,7 @@
 
 package com.velocityctd.proxy.connection.fasttransition;
 
+import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -36,6 +37,20 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.CRC32;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.BinaryTagType;
+import net.kyori.adventure.nbt.ByteArrayBinaryTag;
+import net.kyori.adventure.nbt.ByteBinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.DoubleBinaryTag;
+import net.kyori.adventure.nbt.FloatBinaryTag;
+import net.kyori.adventure.nbt.IntArrayBinaryTag;
+import net.kyori.adventure.nbt.IntBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.LongArrayBinaryTag;
+import net.kyori.adventure.nbt.LongBinaryTag;
+import net.kyori.adventure.nbt.ShortBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -62,7 +77,7 @@ public final class ConfigStateSnapshot {
    * Override with {@code -Dvelocityctd.fasttransition.ignoreTags=false}.
    */
   private static final boolean IGNORE_TAGS = Boolean.parseBoolean(System.getProperty(
-          "velocityctd.fasttransition.ignoreTags", "true"));
+      "velocityctd.fasttransition.ignoreTags", "true"));
 
   private final byte[] fingerprint;
   private final List<String> entries;
@@ -110,12 +125,115 @@ public final class ConfigStateSnapshot {
     /**
      * Doesn't consume the buffer.
      */
-    public void addRegistrySync(ByteBuf content) {
+    public void addRegistrySync(ByteBuf content, ProtocolVersion version) {
       // Copies the readable bytes without advancing the reader index.
-      byte[] data = ByteBufUtil.getBytes(content);
+      byte[] raw = ByteBufUtil.getBytes(content);
       String name = peekRegistryName(content);
-      registryData.put(name, data);
-      dumpPayload((byte) 'R', name, data);
+      // Fingerprint the canonical form (NBT compound keys are unordered, so different server
+      // implementations serialize them in different orders while being fully compatible); dump the raw
+      // bytes so the on-disk capture stays a faithful copy of the wire.
+      registryData.put(name, canonicalize(content, version, raw));
+      dumpPayload((byte) 'R', name, raw);
+    }
+
+    /**
+     * Returns a canonicalized copy of a registry-sync payload in which every entry's NBT has been
+     * re-serialized with compound keys sorted recursively. NBT compounds are unordered maps, so two
+     * server implementations can emit the same registry with different key orderings while being fully
+     * compatible; sorting removes that noise so equal registries fingerprint equal. Falls back to the
+     * raw bytes for pre-1.20.5 formats or on any parse error.
+     */
+    private static byte[] canonicalize(ByteBuf content, ProtocolVersion version, byte[] raw) {
+      if (version.lessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
+        return raw;
+      }
+      ByteBuf in = content.duplicate();
+      ByteBuf out = Unpooled.buffer(raw.length);
+      try {
+        ProtocolUtils.writeString(out, ProtocolUtils.readString(in));
+        int count = ProtocolUtils.readVarInt(in);
+        ProtocolUtils.writeVarInt(out, count);
+        for (int i = 0; i < count; i++) {
+          ProtocolUtils.writeString(out, ProtocolUtils.readString(in));
+          boolean hasData = in.readBoolean();
+          out.writeBoolean(hasData);
+          if (hasData) {
+            canonicalizeTag(ProtocolUtils.readBinaryTag(in, version, null), out);
+          }
+        }
+        return ByteBufUtil.getBytes(out);
+      } catch (Exception e) {
+        LOGGER.debug("Failed to canonicalize registry-sync payload; fingerprinting raw bytes", e);
+        return raw;
+      } finally {
+        out.release();
+      }
+    }
+
+    /**
+     * Writes {@code tag} to {@code out} in a deterministic form: compound keys are emitted in sorted
+     * order and every value is written verbatim, so semantically equal NBT always produces identical
+     * bytes regardless of the source's key ordering. This is a fingerprint form, not valid wire NBT.
+     */
+    private static void canonicalizeTag(BinaryTag tag, ByteBuf out) {
+      BinaryTagType<?> type = tag.type();
+      out.writeByte(type.id());
+      if (tag instanceof CompoundBinaryTag compound) {
+        List<String> keys = new ArrayList<>(compound.keySet());
+        Collections.sort(keys);
+        for (String childKey : keys) {
+          writeUtf(out, childKey);
+          canonicalizeTag(compound.get(childKey), out);
+        }
+        out.writeByte(0); // terminator so key lists of differing length can't collide
+      } else if (tag instanceof ListBinaryTag list) {
+        out.writeByte(list.elementType().id());
+        out.writeInt(list.size());
+        for (BinaryTag element : list) {
+          canonicalizeTag(element, out);
+        }
+      } else if (tag instanceof ByteBinaryTag value) {
+        out.writeByte(value.value());
+      } else if (tag instanceof ShortBinaryTag value) {
+        out.writeShort(value.value());
+      } else if (tag instanceof IntBinaryTag value) {
+        out.writeInt(value.value());
+      } else if (tag instanceof LongBinaryTag value) {
+        out.writeLong(value.value());
+      } else if (tag instanceof FloatBinaryTag value) {
+        out.writeFloat(value.value());
+      } else if (tag instanceof DoubleBinaryTag value) {
+        out.writeDouble(value.value());
+      } else if (tag instanceof StringBinaryTag value) {
+        writeUtf(out, value.value());
+      } else if (tag instanceof ByteArrayBinaryTag value) {
+        byte[] array = value.value();
+        out.writeInt(array.length);
+        out.writeBytes(array);
+      } else if (tag instanceof IntArrayBinaryTag value) {
+        int[] array = value.value();
+        out.writeInt(array.length);
+        for (int element : array) {
+          out.writeInt(element);
+        }
+      } else if (tag instanceof LongArrayBinaryTag value) {
+        long[] array = value.value();
+        out.writeInt(array.length);
+        for (long element : array) {
+          out.writeLong(element);
+        }
+      } else {
+        // EndBinaryTag and any unknown type carry no payload.
+        if (type.id() != 0) {
+          throw new IllegalStateException("Unhandled NBT tag type " + type.id());
+        }
+      }
+    }
+
+    private static void writeUtf(ByteBuf out, String value) {
+      byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+      out.writeShort(bytes.length);
+      out.writeBytes(bytes);
     }
 
     public void addTags(Map<String, Map<String, int[]>> tags) {

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Velocity-CTD Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocityctd.proxy.connection.fasttransition;
+
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.CRC32;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class ConfigStateSnapshot {
+
+  private final byte[] fingerprint;
+  private final List<String> entries;
+
+  private ConfigStateSnapshot(byte[] fingerprint, List<String> entries) {
+    this.fingerprint = fingerprint;
+    this.entries = entries;
+  }
+
+  public boolean matches(@Nullable ConfigStateSnapshot other) {
+    return other != null && Arrays.equals(this.fingerprint, other.fingerprint);
+  }
+
+  public List<String> entries() {
+    return entries;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private final MessageDigest digest;
+    private final List<String> entries = new ArrayList<>();
+
+    private Builder() {
+      try {
+        this.digest = MessageDigest.getInstance("SHA-256");
+      } catch (NoSuchAlgorithmException e) {
+        throw new AssertionError("SHA-256 not available", e);
+      }
+    }
+
+    /**
+     * Doesn't consume the buffer.
+     */
+    public void addRegistrySync(ByteBuf content) {
+      // Copies the readable bytes without advancing the reader index.
+      byte[] data = ByteBufUtil.getBytes(content);
+      update((byte) 'R', peekRegistryName(content), data);
+    }
+
+    public void addTags(Map<String, Map<String, int[]>> tags) {
+      ByteBuf buf = Unpooled.buffer();
+      try {
+        List<String> registries = new ArrayList<>(tags.keySet());
+        Collections.sort(registries);
+        for (String registry : registries) {
+          buf.writeBytes(registry.getBytes(StandardCharsets.UTF_8));
+          buf.writeByte(0);
+          Map<String, int[]> inner = tags.get(registry);
+          List<String> tagNames = new ArrayList<>(inner.keySet());
+          Collections.sort(tagNames);
+          for (String tagName : tagNames) {
+            buf.writeBytes(tagName.getBytes(StandardCharsets.UTF_8));
+            buf.writeByte(0);
+            int[] entries = inner.get(tagName).clone();
+            Arrays.sort(entries);
+            for (int entry : entries) {
+              buf.writeInt(entry);
+            }
+            buf.writeByte(1);
+          }
+        }
+        update((byte) 'T', "tags", ByteBufUtil.getBytes(buf));
+      } finally {
+        buf.release();
+      }
+    }
+
+    private void update(byte tag, String name, byte[] data) {
+      digest.update(tag);
+      // Length-prefix so concatenation boundaries can't collide.
+      digest.update((byte) (data.length >>> 24));
+      digest.update((byte) (data.length >>> 16));
+      digest.update((byte) (data.length >>> 8));
+      digest.update((byte) data.length);
+      digest.update(data);
+
+      CRC32 crc = new CRC32();
+      crc.update(data);
+      entries.add((char) tag + ":" + name + " len=" + data.length + " crc=" + Long.toHexString(crc.getValue()));
+    }
+
+    private static String peekRegistryName(ByteBuf content) {
+      try {
+        return ProtocolUtils.readString(content.duplicate());
+      } catch (Exception e) {
+        return "?";
+      }
+    }
+
+    public ConfigStateSnapshot build() {
+      return new ConfigStateSnapshot(digest.digest(), List.copyOf(entries));
+    }
+  }
+}

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/ConfigStateSnapshot.java
@@ -27,12 +27,27 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.zip.CRC32;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class ConfigStateSnapshot {
+
+  private static final Set<String> IGNORED_REGISTRIES = Set.of(
+      "minecraft:chat_type",
+      "minecraft:test_environment",
+      "minecraft:test_instance");
+
+  /**
+   * Whether tag data is excluded from the fingerprint. Tag sets (block/item/etc.) commonly differ
+   * between server implementations and only affect client-side prediction, not world decoding.
+   * Override with {@code -Dvelocityctd.fasttransition.ignoreTags=false}.
+   */
+  private static final boolean IGNORE_TAGS = Boolean.parseBoolean(System.getProperty(
+          "velocityctd.fasttransition.ignoreTags", "true"));
 
   private final byte[] fingerprint;
   private final List<String> entries;
@@ -56,15 +71,10 @@ public final class ConfigStateSnapshot {
 
   public static final class Builder {
 
-    private final MessageDigest digest;
-    private final List<String> entries = new ArrayList<>();
+    private final Map<String, byte[]> registryData = new LinkedHashMap<>();
+    private byte @Nullable [] tagsData;
 
     private Builder() {
-      try {
-        this.digest = MessageDigest.getInstance("SHA-256");
-      } catch (NoSuchAlgorithmException e) {
-        throw new AssertionError("SHA-256 not available", e);
-      }
     }
 
     /**
@@ -73,7 +83,8 @@ public final class ConfigStateSnapshot {
     public void addRegistrySync(ByteBuf content) {
       // Copies the readable bytes without advancing the reader index.
       byte[] data = ByteBufUtil.getBytes(content);
-      update((byte) 'R', peekRegistryName(content), data);
+      String name = peekRegistryName(content);
+      registryData.put(name, data);
     }
 
     public void addTags(Map<String, Map<String, int[]>> tags) {
@@ -98,13 +109,13 @@ public final class ConfigStateSnapshot {
             buf.writeByte(1);
           }
         }
-        update((byte) 'T', "tags", ByteBufUtil.getBytes(buf));
+        tagsData = ByteBufUtil.getBytes(buf);
       } finally {
         buf.release();
       }
     }
 
-    private void update(byte tag, String name, byte[] data) {
+    private static void hashInto(MessageDigest digest, byte tag, byte[] data) {
       digest.update(tag);
       // Length-prefix so concatenation boundaries can't collide.
       digest.update((byte) (data.length >>> 24));
@@ -112,10 +123,13 @@ public final class ConfigStateSnapshot {
       digest.update((byte) (data.length >>> 8));
       digest.update((byte) data.length);
       digest.update(data);
+    }
 
+    private static String describe(byte tag, String name, byte[] data, boolean ignored) {
       CRC32 crc = new CRC32();
       crc.update(data);
-      entries.add((char) tag + ":" + name + " len=" + data.length + " crc=" + Long.toHexString(crc.getValue()));
+      return (char) tag + ":" + name + " len=" + data.length
+          + " crc=" + Long.toHexString(crc.getValue()) + (ignored ? "  [IGNORED]" : "");
     }
 
     private static String peekRegistryName(ByteBuf content) {
@@ -127,6 +141,30 @@ public final class ConfigStateSnapshot {
     }
 
     public ConfigStateSnapshot build() {
+      MessageDigest digest;
+      try {
+        digest = MessageDigest.getInstance("SHA-256");
+      } catch (NoSuchAlgorithmException e) {
+        throw new AssertionError("SHA-256 not available", e);
+      }
+
+      List<String> entries = new ArrayList<>();
+      List<String> names = new ArrayList<>(registryData.keySet());
+      Collections.sort(names); // order-insensitive fingerprint
+      for (String name : names) {
+        byte[] data = registryData.get(name);
+        boolean ignored = IGNORED_REGISTRIES.contains(name);
+        entries.add(describe((byte) 'R', name, data, ignored));
+        if (!ignored) {
+          hashInto(digest, (byte) 'R', data);
+        }
+      }
+      if (tagsData != null) {
+        entries.add(describe((byte) 'T', "tags", tagsData, IGNORE_TAGS));
+        if (!IGNORE_TAGS) {
+          hashInto(digest, (byte) 'T', tagsData);
+        }
+      }
       return new ConfigStateSnapshot(digest.digest(), List.copyOf(entries));
     }
   }

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
@@ -89,6 +89,10 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
   // cookies, transfers, code of conduct), which forces the fallback reconfiguration.
   private boolean fastTrackable = true;
 
+  // Set when this handler answered the backend's known-packs offer itself, so a fallback knows the
+  // backend is already satisfied and the client's response has to be dropped.
+  private boolean answeredKnownPacks;
+
   private boolean decided;
 
   public FastBackendConfigSessionHandler(VelocityServer server, VelocityServerConnection serverConn,
@@ -124,6 +128,7 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
     List<KnownPacksPacket.KnownPack> clientKnown = serverConn.getPlayer().getClientKnownPacks();
     serverConn.ensureConnected().write(
         clientKnown != null ? new KnownPacksPacket(clientKnown) : packet);
+    answeredKnownPacks = true;
 
     // Buffer the offer: on fallback the client needs it to resolve the registry entries the backend
     // omitted for known packs. The client's response is dropped so the backend isn't answered twice.
@@ -308,8 +313,11 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
     // doSwitch() moves the client into CONFIG; once it resolves the client can receive the
     // backend's buffered configuration.
     clientPlay.doSwitch().thenRunAsync(() -> {
-      // The backend already got its known-packs answer, so drop the client's response.
-      serverConn.getPlayer().setDropKnownPacksResponseToBackend(true);
+      // Only if we answered on the client's behalf: otherwise the backend is still waiting for the
+      // response and an armed drop would leave it stuck in synchronize_registries.
+      if (answeredKnownPacks) {
+        serverConn.getPlayer().setDropKnownPacksResponseToBackend(true);
+      }
       for (MinecraftPacket packet : buffered) {
         replay(normal, packet);
       }

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
@@ -132,7 +132,7 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
 
   @Override
   public boolean handle(RegistrySyncPacket packet) {
-    snapshot.addRegistrySync(packet.content());
+    snapshot.addRegistrySync(packet.content(), serverConn.getPlayer().getProtocolVersion());
     bufferRetained(packet);
     return true;
   }

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
@@ -79,7 +79,7 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
   private final VelocityServerConnection serverConn;
   private final CompletableFuture<Impl> resultFuture;
 
-  private final ConfigStateSnapshot.Builder snapshot = ConfigStateSnapshot.builder();
+  private final ConfigStateSnapshot.Builder snapshot;
 
   // Clientbound config packets, retained in arrival order, replayed to the client only on fallback.
   private final List<MinecraftPacket> buffered = new ArrayList<>();
@@ -95,6 +95,7 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
     this.server = server;
     this.serverConn = serverConn;
     this.resultFuture = resultFuture;
+    this.snapshot = ConfigStateSnapshot.builder("backend-" + serverConn.getServerInfo().getName());
   }
 
   @Override
@@ -197,6 +198,10 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
     ConfigStateSnapshot clientSnapshot = player.getClientConfigSnapshot();
     boolean compatible = backendSnapshot.matches(clientSnapshot);
 
+    if (!compatible) {
+      logSnapshotDiff(player, clientSnapshot, backendSnapshot);
+    }
+
     if (fastTrackable && compatible && clientPlay != null) {
       LOGGER.info("Fast transition for {} to {}: switching in PLAY (compatible registries)",
           player.getUsername(), serverConn.getServerInfo().getName());
@@ -207,6 +212,34 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
           player.getUsername(), serverConn.getServerInfo().getName(),
           fastTrackable, compatible, clientPlay != null);
       fallbackReconfigure(clientPlay);
+    }
+  }
+
+  /**
+   * Logs, line by line, how the client's held configuration (from its current backend) differs from
+   * the target backend's configuration. Ordering matters for the fingerprint, so entries are compared
+   * position-by-position. Set {@code -Dvelocityctd.fasttransition.dumpDir=<dir>} to also dump the raw
+   * payloads for byte-level diffing.
+   */
+  private void logSnapshotDiff(ConnectedPlayer player, @Nullable ConfigStateSnapshot clientSnapshot,
+                               ConfigStateSnapshot backendSnapshot) {
+    if (clientSnapshot == null) {
+      LOGGER.warn("Fast-transition diff for {}: client has no config snapshot", player.getUsername());
+      return;
+    }
+    List<String> client = clientSnapshot.entries();
+    List<String> backend = backendSnapshot.entries();
+    LOGGER.info("Fast-transition config mismatch for {} -> {}: client(fp={}, {} entries) vs backend(fp={}, {} entries)",
+        player.getUsername(), serverConn.getServerInfo().getName(),
+        clientSnapshot.fingerprintHex(), client.size(),
+        backendSnapshot.fingerprintHex(), backend.size());
+    int max = Math.max(client.size(), backend.size());
+    for (int i = 0; i < max; i++) {
+      String c = i < client.size() ? client.get(i) : "<none>";
+      String b = i < backend.size() ? backend.get(i) : "<none>";
+      if (!c.equals(b)) {
+        LOGGER.info("  [{}] client={} | backend={}", i, c, b);
+      }
     }
   }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2026 Velocity-CTD Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocityctd.proxy.connection.fasttransition;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.connection.MinecraftConnection;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.connection.backend.ConfigSessionHandler;
+import com.velocitypowered.proxy.connection.backend.TransitionSessionHandler;
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
+import com.velocitypowered.proxy.connection.client.ClientPlaySessionHandler;
+import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
+import com.velocitypowered.proxy.connection.util.ConnectionMessages;
+import com.velocitypowered.proxy.connection.util.ConnectionRequestResults;
+import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
+import com.velocitypowered.proxy.protocol.packet.ClientboundStoreCookiePacket;
+import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
+import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
+import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
+import com.velocitypowered.proxy.protocol.packet.RemoveResourcePackPacket;
+import com.velocitypowered.proxy.protocol.packet.ResourcePackRequestPacket;
+import com.velocitypowered.proxy.protocol.packet.TransferPacket;
+import com.velocitypowered.proxy.protocol.packet.config.CodeOfConductPacket;
+import com.velocitypowered.proxy.protocol.packet.config.FinishedUpdatePacket;
+import com.velocitypowered.proxy.protocol.packet.config.KnownPacksPacket;
+import com.velocitypowered.proxy.protocol.packet.config.RegistrySyncPacket;
+import com.velocitypowered.proxy.protocol.packet.config.TagsUpdatePacket;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Backend-side configuration handler for the Velocity-CTD fast-transition path.
+ *
+ * <p>Unlike {@link ConfigSessionHandler}, this handler drives the target backend through
+ * configuration without pushing the client into CONFIG: the client stays in PLAY on its current
+ * server. Every clientbound config packet is buffered and fingerprinted, then compared against what
+ * the client holds once the backend finishes:</p>
+ *
+ * <ul>
+ *   <li><b>Compatible</b> - the buffered config is discarded and the backend is advanced to
+ *       PLAY behind a {@link TransitionSessionHandler}; the client is switched entirely in PLAY.</li>
+ *   <li><b>Incompatible</b> (or not fast-trackable) - falls back to a standard
+ *       reconfiguration via a fresh {@link ConfigSessionHandler}, replaying the buffered packets so
+ *       the outcome matches the normal switch.</li>
+ * </ul>
+ */
+public class FastBackendConfigSessionHandler implements MinecraftSessionHandler {
+
+  private static final Logger LOGGER = LogManager.getLogger(FastBackendConfigSessionHandler.class);
+
+  private final VelocityServer server;
+  private final VelocityServerConnection serverConn;
+  private final CompletableFuture<Impl> resultFuture;
+
+  private final ConfigStateSnapshot.Builder snapshot = ConfigStateSnapshot.builder();
+
+  // Clientbound config packets, retained in arrival order, replayed to the client only on fallback.
+  private final List<MinecraftPacket> buffered = new ArrayList<>();
+
+  // Cleared when the backend sends config packets requiring client interaction (resource packs,
+  // cookies, transfers, code of conduct), which forces the fallback reconfiguration.
+  private boolean fastTrackable = true;
+
+  private boolean decided;
+
+  public FastBackendConfigSessionHandler(VelocityServer server, VelocityServerConnection serverConn,
+                                         CompletableFuture<Impl> resultFuture) {
+    this.server = server;
+    this.serverConn = serverConn;
+    this.resultFuture = resultFuture;
+  }
+
+  @Override
+  public boolean beforeHandle() {
+    if (!serverConn.isActive()) {
+      serverConn.disconnect();
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean handle(KeepAlivePacket packet) {
+    // The client is in PLAY on another server, so answer the backend's config keepalive ourselves.
+    serverConn.ensureConnected().write(packet);
+    return true;
+  }
+
+  @Override
+  public boolean handle(KnownPacksPacket packet) {
+    // Reply with the packs the client advertised during its initial configuration, so the backend
+    // produces the same registry data the client holds; echoing the backend's own offer would be
+    // unsafe if it advertises packs the client never had.
+    List<KnownPacksPacket.KnownPack> clientKnown = serverConn.getPlayer().getClientKnownPacks();
+    serverConn.ensureConnected().write(
+        clientKnown != null ? new KnownPacksPacket(clientKnown) : packet);
+
+    // Buffer the offer: on fallback the client needs it to resolve the registry entries the backend
+    // omitted for known packs. The client's response is dropped so the backend isn't answered twice.
+    bufferRetained(packet);
+    return true;
+  }
+
+  @Override
+  public boolean handle(RegistrySyncPacket packet) {
+    snapshot.addRegistrySync(packet.content());
+    bufferRetained(packet);
+    return true;
+  }
+
+  @Override
+  public boolean handle(TagsUpdatePacket packet) {
+    snapshot.addTags(packet.getTags());
+    bufferRetained(packet);
+    return true;
+  }
+
+  @Override
+  public boolean handle(FinishedUpdatePacket packet) {
+    decide();
+    return true;
+  }
+
+  @Override
+  public boolean handle(DisconnectPacket packet) {
+    serverConn.disconnect();
+    if (serverConn.getPlayer().getConnectionInFlight() != null) {
+      resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
+    } else {
+      serverConn.getPlayer().handleConnectionException(serverConn.getServer(), packet, true);
+    }
+    return true;
+  }
+
+  @Override
+  public void handleGeneric(MinecraftPacket packet) {
+    if (packet instanceof ResourcePackRequestPacket
+        || packet instanceof RemoveResourcePackPacket
+        || packet instanceof ClientboundStoreCookiePacket
+        || packet instanceof ClientboundCookieRequestPacket
+        || packet instanceof TransferPacket
+        || packet instanceof CodeOfConductPacket) {
+      // Needs the client to respond in CONFIG; can't be done while it's held in PLAY.
+      fastTrackable = false;
+    }
+    bufferRetained(packet);
+  }
+
+  private void bufferRetained(MinecraftPacket packet) {
+    ReferenceCountUtil.retain(packet);
+    buffered.add(packet);
+  }
+
+  /**
+   * Decides between the fast in-PLAY switch and the fallback reconfiguration once the backend has
+   * finished sending its configuration.
+   */
+  private void decide() {
+    if (decided) {
+      return;
+    }
+    decided = true;
+
+    ConnectedPlayer player = serverConn.getPlayer();
+    ClientPlaySessionHandler clientPlay =
+        player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler h
+            ? h : null;
+    ConfigStateSnapshot backendSnapshot = snapshot.build();
+    ConfigStateSnapshot clientSnapshot = player.getClientConfigSnapshot();
+    boolean compatible = backendSnapshot.matches(clientSnapshot);
+
+    if (fastTrackable && compatible && clientPlay != null) {
+      LOGGER.info("Fast transition for {} to {}: switching in PLAY (compatible registries)",
+          player.getUsername(), serverConn.getServerInfo().getName());
+      fastSwitch(player);
+    } else {
+      LOGGER.info("Fast transition for {} to {}: falling back to reconfiguration "
+              + "(fastTrackable={}, compatible={}, clientInPlay={})",
+          player.getUsername(), serverConn.getServerInfo().getName(),
+          fastTrackable, compatible, clientPlay != null);
+      fallbackReconfigure(clientPlay);
+    }
+  }
+
+  /**
+   * Compatible path: discard the buffered config, advance the backend to PLAY, and let its
+   * {@code JoinGame} drive an in-PLAY server switch with no client reconfiguration.
+   */
+  private void fastSwitch(ConnectedPlayer player) {
+    releaseBuffered();
+
+    MinecraftConnection smc = serverConn.ensureConnected();
+    smc.write(FinishedUpdatePacket.INSTANCE);
+    smc.setActiveSessionHandler(StateRegistry.PLAY,
+        new TransitionSessionHandler(server, serverConn, resultFuture));
+
+    // The client stays in PLAY and never re-sends its brand, so forward the stored brand to the new
+    // backend ourselves; normal reconfiguration relays it via the client's own brand message.
+    String brand = player.getClientBrand();
+    if (brand != null) {
+      ByteBuf brandData = Unpooled.buffer();
+      ProtocolUtils.writeString(brandData, brand);
+      smc.write(new PluginMessagePacket("minecraft:brand", brandData));
+    }
+
+    if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21)) {
+      String target = serverConn.getServerInfo().getName();
+      player.setServerLinks(server.getConfiguration().getServerLinksFor(target));
+    }
+  }
+
+  /**
+   * Fallback path: reproduce the standard reconfiguration by handing the connection to a fresh
+   * {@link ConfigSessionHandler}, taking the client through CONFIG, and replaying the buffered
+   * packets so the backend's config reaches the client exactly as it normally would.
+   */
+  private void fallbackReconfigure(@Nullable ClientPlaySessionHandler clientPlay) {
+    MinecraftConnection smc = serverConn.ensureConnected();
+
+    if (clientPlay == null) {
+      // Should not happen: the fast handler is only installed for in-PLAY switches.
+      LOGGER.error("Cannot fall back to reconfiguration for {}: client is not in PLAY",
+          serverConn.getPlayer().getUsername());
+      releaseBuffered();
+      serverConn.getPlayer().disconnect(ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR);
+      resultFuture.complete(ConnectionRequestResults.forDisconnect(
+          ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR, serverConn.getServer()));
+      return;
+    }
+
+    ConfigSessionHandler normal = new ConfigSessionHandler(server, serverConn, resultFuture);
+    smc.setActiveSessionHandler(StateRegistry.CONFIG, normal);
+    smc.setAutoReading(false);
+
+    // doSwitch() moves the client into CONFIG; once it resolves the client can receive the
+    // backend's buffered configuration.
+    clientPlay.doSwitch().thenRunAsync(() -> {
+      // The backend already got its known-packs answer, so drop the client's response.
+      serverConn.getPlayer().setDropKnownPacksResponseToBackend(true);
+      for (MinecraftPacket packet : buffered) {
+        replay(normal, packet);
+      }
+      buffered.clear();
+      replay(normal, FinishedUpdatePacket.INSTANCE);
+      smc.setAutoReading(true);
+    }, smc.eventLoop()).exceptionally(ex -> {
+      LOGGER.error("Error falling back to reconfiguration for {}", serverConn.getPlayer().getUsername(), ex);
+      releaseBuffered();
+      return null;
+    });
+  }
+
+  private void replay(MinecraftSessionHandler handler, MinecraftPacket packet) {
+    try {
+      if (!packet.handle(handler)) {
+        handler.handleGeneric(packet);
+      }
+    } finally {
+      ReferenceCountUtil.release(packet);
+    }
+  }
+
+  private void releaseBuffered() {
+    for (MinecraftPacket packet : buffered) {
+      ReferenceCountUtil.release(packet);
+    }
+    buffered.clear();
+  }
+
+  @Override
+  public void disconnected() {
+    releaseBuffered();
+    resultFuture.complete(ConnectionRequestResults.forDisconnect(
+        ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR, serverConn.getServer()));
+  }
+
+  @Override
+  public void writabilityChanged() {
+    // Mirror ConfigSessionHandler: relay backend writability to the client's read side.
+    MinecraftConnection smc = serverConn.getConnection();
+    if (smc != null) {
+      serverConn.getPlayer().getConnection().setAutoReading(smc.getChannel().isWritable());
+    }
+  }
+}

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
@@ -17,6 +17,7 @@
 
 package com.velocityctd.proxy.connection.fasttransition;
 
+import com.velocitypowered.api.event.player.configuration.PlayerBackendConfigurationEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
@@ -213,6 +214,17 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
           fastTrackable, compatible, clientPlay != null);
       fallbackReconfigure(clientPlay);
     }
+  }
+
+  public CompletableFuture<Void> fireBackendConfigurationEvent() {
+    ConnectedPlayer player = serverConn.getPlayer();
+    return server.getEventManager().fire(new PlayerBackendConfigurationEvent(player, serverConn))
+        .handle((ignored, ex) -> {
+          if (ex != null) {
+            LOGGER.error("Error running fast-transition backend configuration event for {}", player, ex);
+          }
+          return null;
+        });
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -905,6 +905,16 @@ public final class VelocityConfiguration implements ProxyConfig {
   }
 
   /**
+   * Returns whether 1.20.2+ players switching backends skip the client-visible configuration phase
+   * when the registries are compatible, completing the switch entirely in the PLAY state.
+   *
+   * @return {@code true} if the fast server-switch path is enabled
+   */
+  public boolean isFastServerSwitch() {
+    return advanced.isFastServerSwitch();
+  }
+
+  /**
    * Gets the dynamic fallback filter mode configured for server selection.
    *
    * @return the fallback filter identifier
@@ -2091,6 +2101,13 @@ public final class VelocityConfiguration implements ProxyConfig {
     @Expose
     private boolean poolPlayersAcrossSections = false;
 
+    /**
+     * Whether 1.20.2+ players switching backends skip the client-visible configuration phase when the
+     * registries are compatible, completing the switch entirely in the PLAY state.
+     */
+    @Expose
+    private boolean fastServerSwitch = false;
+
     private Advanced() {
     }
 
@@ -2131,6 +2148,7 @@ public final class VelocityConfiguration implements ProxyConfig {
         this.backendBrandCustom = config.getOrElse("custom-brand-backend", "Paper");
         this.ignoreAnonymousPlayerRequest = config.getOrElse("ignore-anonymous-player-request", false);
         this.poolPlayersAcrossSections = config.getOrElse("pool-players-across-sections", false);
+        this.fastServerSwitch = config.getOrElse("fast-server-switch", false);
       }
     }
 
@@ -2250,6 +2268,10 @@ public final class VelocityConfiguration implements ProxyConfig {
       return poolPlayersAcrossSections;
     }
 
+    public boolean isFastServerSwitch() {
+      return fastServerSwitch;
+    }
+
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
@@ -2281,6 +2303,7 @@ public final class VelocityConfiguration implements ProxyConfig {
           .add("backendBrandCustom", backendBrandCustom)
           .add("ignoreAnonymousPlayerRequest", ignoreAnonymousPlayerRequest)
           .add("poolPlayersAcrossSections", poolPlayersAcrossSections)
+          .add("fastServerSwitch", fastServerSwitch)
           .toString();
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
@@ -41,6 +41,7 @@ import com.velocitypowered.proxy.protocol.packet.LegacyPlayerListItemPacket;
 import com.velocitypowered.proxy.protocol.packet.LoginAcknowledgedPacket;
 import com.velocitypowered.proxy.protocol.packet.LoginPluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.LoginPluginResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.ObjectivePacket;
 import com.velocitypowered.proxy.protocol.packet.PingIdentifyPacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.RemovePlayerInfoPacket;
@@ -59,6 +60,7 @@ import com.velocitypowered.proxy.protocol.packet.StatusRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.StatusResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.TeamPacket;
 import com.velocitypowered.proxy.protocol.packet.TransferPacket;
 import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
@@ -388,6 +390,14 @@ public interface MinecraftSessionHandler {
   }
 
   default boolean handle(ClientboundStopSoundPacket packet) {
+    return false;
+  }
+
+  default boolean handle(ObjectivePacket packet) {
+    return false;
+  }
+
+  default boolean handle(TeamPacket packet) {
     return false;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -53,6 +53,7 @@ import com.velocitypowered.proxy.protocol.packet.ClientboundStoreCookiePacket;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
 import com.velocitypowered.proxy.protocol.packet.LegacyPlayerListItemPacket;
+import com.velocitypowered.proxy.protocol.packet.ObjectivePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.RemovePlayerInfoPacket;
 import com.velocitypowered.proxy.protocol.packet.RemoveResourcePackPacket;
@@ -60,6 +61,7 @@ import com.velocitypowered.proxy.protocol.packet.ResourcePackRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.ServerDataPacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.TeamPacket;
 import com.velocitypowered.proxy.protocol.packet.TransferPacket;
 import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
@@ -190,12 +192,32 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(BossBarPacket packet) {
-    if (serverConn.getPlayer().getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_20_2)) {
-      if (packet.getAction() == BossBarPacket.ADD) {
-        playerSessionHandler.getServerBossBars().add(packet.getUuid());
-      } else if (packet.getAction() == BossBarPacket.REMOVE) {
-        playerSessionHandler.getServerBossBars().remove(packet.getUuid());
-      }
+    if (packet.getAction() == BossBarPacket.ADD) {
+      playerSessionHandler.getServerBossBars().add(packet.getUuid());
+    } else if (packet.getAction() == BossBarPacket.REMOVE) {
+      playerSessionHandler.getServerBossBars().remove(packet.getUuid());
+    }
+
+    return false; // Forward
+  }
+
+  @Override
+  public boolean handle(ObjectivePacket packet) {
+    if (packet.getAction() == ObjectivePacket.ADD) {
+      playerSessionHandler.getServerObjectives().add(packet.getName());
+    } else if (packet.getAction() == ObjectivePacket.REMOVE) {
+      playerSessionHandler.getServerObjectives().remove(packet.getName());
+    }
+
+    return false; // Forward
+  }
+
+  @Override
+  public boolean handle(TeamPacket packet) {
+    if (packet.getMode() == TeamPacket.ADD) {
+      playerSessionHandler.getServerTeams().add(packet.getName());
+    } else if (packet.getMode() == TeamPacket.REMOVE) {
+      playerSessionHandler.getServerTeams().remove(packet.getName());
     }
 
     return false; // Forward

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -17,6 +17,7 @@
 
 package com.velocitypowered.proxy.connection.backend;
 
+import com.velocityctd.proxy.connection.fasttransition.ConfigStateSnapshot;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.connection.PreTransferEvent;
 import com.velocitypowered.api.event.player.CookieRequestEvent;
@@ -98,6 +99,10 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   private final State state;
 
+  // Fingerprints the registry/tag data forwarded to the client, committed as its snapshot when the
+  // backend finishes, feeding the fast-transition decision.
+  private final ConfigStateSnapshot.Builder configSnapshot = ConfigStateSnapshot.builder();
+
   // Guards advanceBackendToPlay; only touched on the backend event loop.
   private boolean backendAdvancedToPlay;
 
@@ -108,8 +113,8 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
    * @param serverConn   the server connection
    * @param resultFuture the result future
    */
-  ConfigSessionHandler(VelocityServer server, VelocityServerConnection serverConn,
-                       CompletableFuture<Impl> resultFuture) {
+  public ConfigSessionHandler(VelocityServer server, VelocityServerConnection serverConn,
+                              CompletableFuture<Impl> resultFuture) {
     this.server = server;
     this.serverConn = serverConn;
     this.resultFuture = resultFuture;
@@ -144,6 +149,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(TagsUpdatePacket packet) {
+    configSnapshot.addTags(packet.getTags());
     serverConn.getPlayer().getConnection().write(packet);
     return true;
   }
@@ -256,6 +262,9 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
   public boolean handle(FinishedUpdatePacket packet) {
     MinecraftConnection smc = serverConn.ensureConnected();
     ConnectedPlayer player = serverConn.getPlayer();
+
+    player.setClientConfigSnapshot(configSnapshot.build());
+
     ClientConfigSessionHandler configHandler = (ClientConfigSessionHandler) player.getConnection().getActiveSessionHandler();
 
     smc.getChannel().pipeline().get(MinecraftVarintFrameDecoder.class).setState(StateRegistry.PLAY);
@@ -352,6 +361,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(RegistrySyncPacket packet) {
+    configSnapshot.addRegistrySync(packet.content());
     serverConn.getPlayer().getConnection().write(packet.retain());
     return true;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -362,7 +362,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(RegistrySyncPacket packet) {
-    configSnapshot.addRegistrySync(packet.content());
+    configSnapshot.addRegistrySync(packet.content(), serverConn.getPlayer().getProtocolVersion());
     serverConn.getPlayer().getConnection().write(packet.retain());
     return true;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -25,6 +25,7 @@ import com.velocitypowered.api.event.player.CookieStoreEvent;
 import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.event.player.ServerResourcePackRemoveEvent;
 import com.velocitypowered.api.event.player.ServerResourcePackSendEvent;
+import com.velocitypowered.api.event.player.configuration.PlayerBackendConfigurationEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.player.ResourcePackInfo;
@@ -120,6 +121,17 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
     this.resultFuture = resultFuture;
     this.state = State.START;
     this.configSnapshot = ConfigStateSnapshot.builder("client-" + serverConn.getServerInfo().getName());
+  }
+
+  public CompletableFuture<Void> fireBackendConfigurationEvent() {
+    ConnectedPlayer player = serverConn.getPlayer();
+    return server.getEventManager().fire(new PlayerBackendConfigurationEvent(player, serverConn))
+        .handle((ignored, ex) -> {
+          if (ex != null) {
+            LOGGER.error("Error running backend configuration event for {}", player, ex);
+          }
+          return null;
+        });
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -101,7 +101,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   // Fingerprints the registry/tag data forwarded to the client, committed as its snapshot when the
   // backend finishes, feeding the fast-transition decision.
-  private final ConfigStateSnapshot.Builder configSnapshot = ConfigStateSnapshot.builder();
+  private final ConfigStateSnapshot.Builder configSnapshot;
 
   // Guards advanceBackendToPlay; only touched on the backend event loop.
   private boolean backendAdvancedToPlay;
@@ -119,6 +119,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
     this.serverConn = serverConn;
     this.resultFuture = resultFuture;
     this.state = State.START;
+    this.configSnapshot = ConfigStateSnapshot.builder("client-" + serverConn.getServerInfo().getName());
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -63,13 +63,6 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
 
   private static final Component MODERN_IP_FORWARDING_FAILURE = Component.translatable("velocity.error.modern-forwarding-failed");
 
-  /**
-   * Enables the Velocity-CTD fast-transition server-switch path: when a 1.20.2+ player moves between
-   * backends with compatible registries, the client-visible CONFIG phase is skipped and the switch
-   * happens entirely in PLAY, falling back to the standard CONFIG switch otherwise.
-   */
-  public static final boolean FAST_TRANSITION = Boolean.getBoolean("velocity-ctd.fast-transition");
-
   private final VelocityServer server;
 
   private final VelocityServerConnection serverConn;
@@ -179,7 +172,8 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
       // Velocity-CTD fast transition: when switching an already-playing client, configure the target
       // ourselves while the client stays in PLAY. The fast handler skips CONFIG when the registries
       // are compatible and otherwise falls back to a standard reconfiguration.
-      boolean fastTransition = FAST_TRANSITION && player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler;
+      boolean fastTransition = server.getConfiguration().isFastServerSwitch()
+          && player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler;
 
       if (fastTransition) {
         smc.setActiveSessionHandler(StateRegistry.CONFIG,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -166,7 +166,6 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
     if (smc.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_20_2)) {
       smc.setActiveSessionHandler(StateRegistry.PLAY, new TransitionSessionHandler(server, serverConn, resultFuture));
     } else {
-      smc.write(new LoginAcknowledgedPacket());
       ConnectedPlayer player = serverConn.getPlayer();
 
       // Velocity-CTD fast transition: when switching an already-playing client, configure the target
@@ -175,24 +174,33 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
       boolean fastTransition = server.getConfiguration().isFastServerSwitch()
           && player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler;
 
+      smc.setAutoReading(false);
       if (fastTransition) {
-        smc.setActiveSessionHandler(StateRegistry.CONFIG,
-            new FastBackendConfigSessionHandler(server, serverConn, resultFuture));
+        smc.write(new LoginAcknowledgedPacket());
+        FastBackendConfigSessionHandler fastHandler =
+            new FastBackendConfigSessionHandler(server, serverConn, resultFuture);
+        smc.setActiveSessionHandler(StateRegistry.CONFIG, fastHandler);
+        CompletableFuture<Void> backendConfigEvent = fastHandler.fireBackendConfigurationEvent();
         if (player.getClientSettingsPacket() != null) {
           smc.write(player.getClientSettingsPacket());
         }
+        backendConfigEvent.thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
       } else {
-        smc.setActiveSessionHandler(StateRegistry.CONFIG, new ConfigSessionHandler(server, serverConn, resultFuture));
+        smc.write(new LoginAcknowledgedPacket());
+        ConfigSessionHandler configHandler = new ConfigSessionHandler(server, serverConn, resultFuture);
+        smc.setActiveSessionHandler(StateRegistry.CONFIG, configHandler);
+        CompletableFuture<Void> backendConfigEvent = configHandler.fireBackendConfigurationEvent();
         if (player.getClientSettingsPacket() != null) {
           smc.write(player.getClientSettingsPacket());
         }
 
         if (player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler clientPlaySessionHandler) {
-          smc.setAutoReading(false);
-          clientPlaySessionHandler.doSwitch().thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
+          CompletableFuture.allOf(backendConfigEvent, clientPlaySessionHandler.doSwitch())
+              .thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
         } else {
           // Initial login - the player is already in configuration state.
           server.getEventManager().fireAndForget(new PlayerEnteredConfigurationEvent(player, serverConn));
+          backendConfigEvent.thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
         }
       }
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -17,6 +17,7 @@
 
 package com.velocitypowered.proxy.connection.backend;
 
+import com.velocityctd.proxy.connection.fasttransition.FastBackendConfigSessionHandler;
 import com.velocitypowered.api.event.player.CookieRequestEvent;
 import com.velocitypowered.api.event.player.ServerLoginPluginMessageEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerEnteredConfigurationEvent;
@@ -61,6 +62,13 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
   }
 
   private static final Component MODERN_IP_FORWARDING_FAILURE = Component.translatable("velocity.error.modern-forwarding-failed");
+
+  /**
+   * Enables the Velocity-CTD fast-transition server-switch path: when a 1.20.2+ player moves between
+   * backends with compatible registries, the client-visible CONFIG phase is skipped and the switch
+   * happens entirely in PLAY, falling back to the standard CONFIG switch otherwise.
+   */
+  public static final boolean FAST_TRANSITION = Boolean.getBoolean("velocity-ctd.fast-transition");
 
   private final VelocityServer server;
 
@@ -166,18 +174,32 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
       smc.setActiveSessionHandler(StateRegistry.PLAY, new TransitionSessionHandler(server, serverConn, resultFuture));
     } else {
       smc.write(new LoginAcknowledgedPacket());
-      smc.setActiveSessionHandler(StateRegistry.CONFIG, new ConfigSessionHandler(server, serverConn, resultFuture));
       ConnectedPlayer player = serverConn.getPlayer();
-      if (player.getClientSettingsPacket() != null) {
-        smc.write(player.getClientSettingsPacket());
-      }
 
-      if (player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler clientPlaySessionHandler) {
-        smc.setAutoReading(false);
-        clientPlaySessionHandler.doSwitch().thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
+      // Velocity-CTD fast transition: when switching an already-playing client, configure the target
+      // ourselves while the client stays in PLAY. The fast handler skips CONFIG when the registries
+      // are compatible and otherwise falls back to a standard reconfiguration.
+      boolean fastTransition = FAST_TRANSITION && player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler;
+
+      if (fastTransition) {
+        smc.setActiveSessionHandler(StateRegistry.CONFIG,
+            new FastBackendConfigSessionHandler(server, serverConn, resultFuture));
+        if (player.getClientSettingsPacket() != null) {
+          smc.write(player.getClientSettingsPacket());
+        }
       } else {
-        // Initial login - the player is already in configuration state.
-        server.getEventManager().fireAndForget(new PlayerEnteredConfigurationEvent(player, serverConn));
+        smc.setActiveSessionHandler(StateRegistry.CONFIG, new ConfigSessionHandler(server, serverConn, resultFuture));
+        if (player.getClientSettingsPacket() != null) {
+          smc.write(player.getClientSettingsPacket());
+        }
+
+        if (player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler clientPlaySessionHandler) {
+          smc.setAutoReading(false);
+          clientPlaySessionHandler.doSwitch().thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
+        } else {
+          // Initial login - the player is already in configuration state.
+          server.getEventManager().fireAndForget(new PlayerEnteredConfigurationEvent(player, serverConn));
+        }
       }
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -77,9 +77,9 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
    * @param serverConn   the server connection
    * @param resultFuture the result future
    */
-  TransitionSessionHandler(VelocityServer server,
-                           VelocityServerConnection serverConn,
-                           CompletableFuture<Impl> resultFuture) {
+  public TransitionSessionHandler(VelocityServer server,
+                                  VelocityServerConnection serverConn,
+                                  CompletableFuture<Impl> resultFuture) {
     this.server = server;
     this.serverConn = serverConn;
     this.resultFuture = resultFuture;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -91,6 +91,7 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   private CompletableFuture<Void> configSwitchFuture;
 
   private boolean configuredOnce;
+  private boolean knownPacksResponseForwarded;
 
   // Active resource pack hold and its keepalive task, or null when no hold is in progress.
   private volatile @Nullable CompletableFuture<Void> resourcePackHold;
@@ -205,6 +206,11 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
     if (player.consumeDropKnownPacksResponseToBackend()) {
       return true;
     }
+
+    if (knownPacksResponseForwarded) {
+      return true;
+    }
+    knownPacksResponseForwarded = true;
 
     callConfigurationEvent().thenRun(() -> {
       VelocityServerConnection targetServer = player.getConnectionInFlightOrConnectedServer();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -91,7 +91,7 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   private CompletableFuture<Void> configSwitchFuture;
 
   private boolean configuredOnce;
-  private boolean knownPacksResponseForwarded;
+  private boolean knownPacksAnswered;
 
   // Active resource pack hold and its keepalive task, or null when no hold is in progress.
   private volatile @Nullable CompletableFuture<Void> resourcePackHold;
@@ -111,11 +111,13 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   @Override
   public void activated() {
     configSwitchFuture = new CompletableFuture<>();
+    knownPacksAnswered = false;
   }
 
   @Override
   public void deactivated() {
     configurationFuture = null;
+    player.setDropKnownPacksResponseToBackend(false);
   }
 
   @Override
@@ -203,21 +205,41 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   public boolean handle(KnownPacksPacket packet) {
     player.setClientKnownPacks(packet.getPacks());
 
-    if (player.consumeDropKnownPacksResponseToBackend()) {
-      return true;
-    }
+    boolean dropped = player.consumeDropKnownPacksResponseToBackend();
+    boolean duplicate = knownPacksAnswered;
+    knownPacksAnswered = true;
 
-    if (knownPacksResponseForwarded) {
-      return true;
-    }
-    knownPacksResponseForwarded = true;
-
-    callConfigurationEvent().thenRun(() -> {
+    if (dropped || duplicate) {
       VelocityServerConnection targetServer = player.getConnectionInFlightOrConnectedServer();
-      if (targetServer != null) {
-        targetServer.ensureConnected().write(packet);
+      LOGGER.warn("Suppressing known packs response from {} (reason={}, target={})", player,
+          duplicate ? "duplicate-in-configuration" : "already-answered-by-fast-transition",
+          targetServer == null ? "<none>" : targetServer.getServerInfo().getName());
+      return true;
+    }
+
+    VelocityServerConnection targetServer = player.getConnectionInFlightOrConnectedServer();
+    if (targetServer == null) {
+      return true;
+    }
+
+    MinecraftConnection smc = targetServer.getConnection();
+    if (smc == null) {
+      return true;
+    }
+
+    callConfigurationEvent().thenRunAsync(() -> {
+      if (smc.isClosed()) {
+        return;
       }
-    }).exceptionally(ex -> {
+
+      if (smc.getState() != StateRegistry.CONFIG) {
+        LOGGER.warn("Dropping late known packs response from {}: {} left the configuration state",
+            player, targetServer.getServerInfo().getName());
+        return;
+      }
+
+      smc.write(packet);
+    }, smc.eventLoop()).exceptionally(ex -> {
       LOGGER.error("Error forwarding known packs response to backend:", ex);
       return null;
     });

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -200,6 +200,12 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(KnownPacksPacket packet) {
+    player.setClientKnownPacks(packet.getPacks());
+
+    if (player.consumeDropKnownPacksResponseToBackend()) {
+      return true;
+    }
+
     callConfigurationEvent().thenRun(() -> {
       VelocityServerConnection targetServer = player.getConnectionInFlightOrConnectedServer();
       if (targetServer != null) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -47,6 +47,7 @@ import com.velocitypowered.proxy.protocol.packet.BossBarPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
+import com.velocitypowered.proxy.protocol.packet.ObjectivePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.RespawnPacket;
@@ -54,6 +55,7 @@ import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket
 import com.velocitypowered.proxy.protocol.packet.TabCompleteRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket.Offer;
+import com.velocitypowered.proxy.protocol.packet.TeamPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatHandler;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatTimeKeeper;
@@ -82,8 +84,10 @@ import io.netty.util.ReferenceCountUtil;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -121,6 +125,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
   private boolean spawned = false;
 
   private final List<UUID> serverBossBars = new ArrayList<>();
+  private final Set<String> serverObjectives = new HashSet<>();
+  private final Set<String> serverTeams = new HashSet<>();
 
   private final Queue<PluginMessagePacket> loginPluginMessages = new ConcurrentLinkedQueue<>();
 
@@ -622,10 +628,11 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       spawned = false;
       player.clearPlayerListHeaderAndFooterSilent();
       player.getTabList().clearAllSilent();
+      serverObjectives.clear();
+      serverTeams.clear();
+      serverBossBars.clear();
       if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_2)) {
         player.getBossBarManager().dropPackets();
-      } else {
-        serverBossBars.clear();
       }
     }
 
@@ -668,18 +675,34 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
     if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_2)) {
       player.getBossBarManager().sendBossBars();
-    } else {
-      // Remove previous boss bars. These don't get cleared when sending JoinGame (up until 1.20.2),
-      // thus the need to track them.
-      for (UUID serverBossBar : serverBossBars) {
-        BossBarPacket deletePacket = new BossBarPacket();
-        deletePacket.setUuid(serverBossBar);
-        deletePacket.setAction(BossBarPacket.REMOVE);
-        player.getConnection().delayedWrite(deletePacket);
-      }
-
-      serverBossBars.clear();
     }
+
+    // Remove previous server-created boss bars. Pre-1.20.2 these are never cleared by JoinGame; on
+    // 1.20.2+ the configuration phase clears them (and the set is emptied in doSwitch), so this is a
+    // no-op there EXCEPT on a fast transition that stays in PLAY, where it is what removes them.
+    for (UUID serverBossBar : serverBossBars) {
+      BossBarPacket deletePacket = new BossBarPacket();
+      deletePacket.setUuid(serverBossBar);
+      deletePacket.setAction(BossBarPacket.REMOVE);
+      player.getConnection().delayedWrite(deletePacket);
+    }
+    serverBossBars.clear();
+
+    for (String serverObjective : serverObjectives) {
+      ObjectivePacket deletePacket = new ObjectivePacket();
+      deletePacket.setName(serverObjective);
+      deletePacket.setAction(ObjectivePacket.REMOVE);
+      player.getConnection().delayedWrite(deletePacket);
+    }
+
+    serverObjectives.clear();
+    for (String serverTeam : serverTeams) {
+      TeamPacket deletePacket = new TeamPacket();
+      deletePacket.setName(serverTeam);
+      deletePacket.setMode(TeamPacket.REMOVE);
+      player.getConnection().delayedWrite(deletePacket);
+    }
+    serverTeams.clear();
 
     // Tell the server about the proxy's plugin message channels.
     ProtocolVersion serverVersion = serverMc.getProtocolVersion();
@@ -757,6 +780,14 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
   public List<UUID> getServerBossBars() {
     return serverBossBars;
+  }
+
+  public Set<String> getServerObjectives() {
+    return serverObjectives;
+  }
+
+  public Set<String> getServerTeams() {
+    return serverTeams;
   }
 
   private boolean handleCommandTabComplete(TabCompleteRequestPacket packet) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -32,6 +32,7 @@ import com.mojang.brigadier.tree.RootCommandNode;
 import com.velocityctd.api.event.permission.PermissionsChangeEvent;
 import com.velocityctd.api.permission.PermissionResolver;
 import com.velocityctd.api.queue.QueueState;
+import com.velocityctd.proxy.connection.fasttransition.ConfigStateSnapshot;
 import com.velocityctd.proxy.permission.PermissionUtils;
 import com.velocityctd.proxy.queue.VelocityQueue;
 import com.velocityctd.proxy.util.ComponentUtils;
@@ -110,6 +111,7 @@ import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderFactory
 import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderV2;
 import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyChatPacket;
 import com.velocitypowered.proxy.protocol.packet.config.ClientboundServerLinksPacket;
+import com.velocitypowered.proxy.protocol.packet.config.KnownPacksPacket;
 import com.velocitypowered.proxy.protocol.packet.config.StartUpdatePacket;
 import com.velocitypowered.proxy.protocol.packet.title.GenericTitlePacket;
 import com.velocitypowered.proxy.protocol.util.ByteBufDataOutput;
@@ -305,6 +307,14 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   private @Nullable ClientSettingsPacket clientSettingsPacket;
 
+  private @Nullable ConfigStateSnapshot clientConfigSnapshot;
+
+  private @Nullable List<KnownPacksPacket.KnownPack> clientKnownPacks;
+
+  // Set by the fast-transition fallback: the backend was already answered, so the client's next
+  // known-packs response must be dropped. Only touched on the client event loop.
+  private boolean dropKnownPacksResponseToBackend;
+
   private volatile ChatQueue chatQueue;
 
   private final ChatBuilderFactory chatBuilderFactory;
@@ -490,6 +500,44 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   @Nullable
   public ClientSettingsPacket getClientSettingsPacket() {
     return clientSettingsPacket;
+  }
+
+  /**
+   * Returns the fingerprint of the registry/tag data the client currently holds, or {@code null}
+   * if the client has not yet completed a configuration.
+   */
+  public @Nullable ConfigStateSnapshot getClientConfigSnapshot() {
+    return clientConfigSnapshot;
+  }
+
+  public void setClientConfigSnapshot(@Nullable ConfigStateSnapshot clientConfigSnapshot) {
+    this.clientConfigSnapshot = clientConfigSnapshot;
+  }
+
+  /**
+   * Returns the known packs the client last advertised during configuration, or {@code null} if the
+   * client never negotiated known packs (pre-1.20.5).
+   */
+  public @Nullable List<KnownPacksPacket.KnownPack> getClientKnownPacks() {
+    return clientKnownPacks;
+  }
+
+  public void setClientKnownPacks(@Nullable List<KnownPacksPacket.KnownPack> clientKnownPacks) {
+    this.clientKnownPacks = clientKnownPacks;
+  }
+
+  public void setDropKnownPacksResponseToBackend(boolean drop) {
+    this.dropKnownPacksResponseToBackend = drop;
+  }
+
+  /**
+   * Returns whether the client's next known-packs response should be dropped instead of forwarded to
+   * the backend (fast-transition fallback), clearing the flag.
+   */
+  public boolean consumeDropKnownPacksResponseToBackend() {
+    boolean drop = this.dropKnownPacksResponseToBackend;
+    this.dropKnownPacksResponseToBackend = false;
+    return drop;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -77,6 +77,7 @@ import com.velocitypowered.proxy.protocol.packet.LegacyPlayerListItemPacket;
 import com.velocitypowered.proxy.protocol.packet.LoginAcknowledgedPacket;
 import com.velocitypowered.proxy.protocol.packet.LoginPluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.LoginPluginResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.ObjectivePacket;
 import com.velocitypowered.proxy.protocol.packet.PingIdentifyPacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.RemovePlayerInfoPacket;
@@ -95,6 +96,7 @@ import com.velocitypowered.proxy.protocol.packet.StatusRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.StatusResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.TeamPacket;
 import com.velocitypowered.proxy.protocol.packet.TransferPacket;
 import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
@@ -487,6 +489,50 @@ public enum StateRegistry {
           map(0x70, MINECRAFT_1_21_5, true),
           map(0x75, MINECRAFT_1_21_9, true),
           map(0x77, MINECRAFT_26_1, true));
+      // CTD ADDITION
+      clientbound.register(
+          ObjectivePacket.class,
+          ObjectivePacket::new,
+          map(0x3B, MINECRAFT_1_8, false),
+          map(0x3F, MINECRAFT_1_9, false),
+          map(0x41, MINECRAFT_1_12, false),
+          map(0x42, MINECRAFT_1_12_1, false),
+          map(0x45, MINECRAFT_1_13, false),
+          map(0x49, MINECRAFT_1_14, false),
+          map(0x4A, MINECRAFT_1_15, false),
+          map(0x53, MINECRAFT_1_17, false),
+          map(0x56, MINECRAFT_1_19_1, false),
+          map(0x54, MINECRAFT_1_19_3, false),
+          map(0x58, MINECRAFT_1_19_4, false),
+          map(0x5A, MINECRAFT_1_20_2, false),
+          map(0x5C, MINECRAFT_1_20_3, false),
+          map(0x5E, MINECRAFT_1_20_5, false),
+          map(0x64, MINECRAFT_1_21_2, false),
+          map(0x63, MINECRAFT_1_21_5, false),
+          map(0x68, MINECRAFT_1_21_9, false),
+          map(0x6A, MINECRAFT_26_1, false));
+      // CTD ADDITION
+      clientbound.register(
+          TeamPacket.class,
+          TeamPacket::new,
+          map(0x3E, MINECRAFT_1_8, false),
+          map(0x41, MINECRAFT_1_9, false),
+          map(0x43, MINECRAFT_1_12, false),
+          map(0x44, MINECRAFT_1_12_1, false),
+          map(0x47, MINECRAFT_1_13, false),
+          map(0x4B, MINECRAFT_1_14, false),
+          map(0x4C, MINECRAFT_1_15, false),
+          map(0x55, MINECRAFT_1_17, false),
+          map(0x58, MINECRAFT_1_19_1, false),
+          map(0x56, MINECRAFT_1_19_3, false),
+          map(0x5A, MINECRAFT_1_19_4, false),
+          map(0x5C, MINECRAFT_1_20_2, false),
+          map(0x5E, MINECRAFT_1_20_3, false),
+          map(0x60, MINECRAFT_1_20_5, false),
+          map(0x67, MINECRAFT_1_21_2, false),
+          map(0x66, MINECRAFT_1_21_5, false),
+          map(0x6B, MINECRAFT_1_21_9, false),
+          map(0x6D, MINECRAFT_26_1, false));
       clientbound.register(
           PluginMessagePacket.class,
           PluginMessagePacket::new,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ObjectivePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ObjectivePacket.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Clientbound scoreboard "set objective" packet.
+ *
+ * <p>Only the leading {@code name} and {@code action} fields are decoded. Their layout has been stable since 1.8.
+ */
+public class ObjectivePacket implements MinecraftPacket {
+
+  public static final byte ADD = 0;
+  public static final byte REMOVE = 1;
+  public static final byte UPDATE = 2;
+
+  private static final byte[] EMPTY = new byte[0];
+
+  private String name = "";
+  private byte action;
+  // Everything after the action byte, preserved unparsed so forwarding is version-agnostic.
+  private byte[] rest = EMPTY;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public byte getAction() {
+    return action;
+  }
+
+  public void setAction(byte action) {
+    this.action = action;
+  }
+
+  @Override
+  public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
+    name = ProtocolUtils.readString(buf);
+    action = buf.readByte();
+    rest = new byte[buf.readableBytes()];
+    buf.readBytes(rest);
+  }
+
+  @Override
+  public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
+    ProtocolUtils.writeString(buf, name);
+    buf.writeByte(action);
+    buf.writeBytes(rest);
+  }
+
+  @Override
+  public boolean handle(MinecraftSessionHandler handler) {
+    return handler.handle(this);
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/TeamPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/TeamPacket.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Clientbound scoreboard "set player team" packet.
+ *
+ * <p>Only the leading {@code name} and {@code mode} fields are decoded. Their layout has been stable since 1.8.
+ */
+public class TeamPacket implements MinecraftPacket {
+
+  public static final byte ADD = 0;
+  public static final byte REMOVE = 1;
+  public static final byte UPDATE = 2;
+  public static final byte ADD_PLAYER = 3;
+  public static final byte REMOVE_PLAYER = 4;
+
+  private static final byte[] EMPTY = new byte[0];
+
+  private String name = "";
+  private byte mode;
+  // Everything after the mode byte, preserved unparsed so forwarding is version-agnostic.
+  private byte[] rest = EMPTY;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public byte getMode() {
+    return mode;
+  }
+
+  public void setMode(byte mode) {
+    this.mode = mode;
+  }
+
+  @Override
+  public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
+    name = ProtocolUtils.readString(buf);
+    mode = buf.readByte();
+    rest = new byte[buf.readableBytes()];
+    buf.readBytes(rest);
+  }
+
+  @Override
+  public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
+    ProtocolUtils.writeString(buf, name);
+    buf.writeByte(mode);
+    buf.writeBytes(rest);
+  }
+
+  @Override
+  public boolean handle(MinecraftSessionHandler handler) {
+    return handler.handle(this);
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/KnownPacksPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/KnownPacksPacket.java
@@ -33,6 +33,17 @@ public class KnownPacksPacket implements MinecraftPacket {
 
   private List<KnownPack> packs;
 
+  public KnownPacksPacket() {
+  }
+
+  public KnownPacksPacket(List<KnownPack> packs) {
+    this.packs = packs;
+  }
+
+  public List<KnownPack> getPacks() {
+    return packs;
+  }
+
   @Override
   public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
     int packCount = ProtocolUtils.readVarInt(buf);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/TagsUpdatePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/TagsUpdatePacket.java
@@ -39,6 +39,10 @@ public class TagsUpdatePacket implements MinecraftPacket {
     this.tags = Map.of();
   }
 
+  public Map<String, Map<String, int[]>> getTags() {
+    return tags;
+  }
+
   @Override
   public void decode(ByteBuf buf, ProtocolUtils.Direction direction,
                      ProtocolVersion protocolVersion) {

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -415,6 +415,11 @@ ignore-anonymous-player-request = false
 # more than one section.
 pool-players-across-sections = false
 
+# When a 1.20.2+ player switches backends and the registries are compatible, skip the
+# client-visible configuration phase and complete the switch entirely in the PLAY state,
+# which avoids the reconfiguration flicker. Falls back to a normal switch when incompatible.
+fast-server-switch = false
+
 [slash-servers]
 # Defines "/<name>" aliases for servers - here "/faction" and "/factions" would both send you to the server named
 # "factions", for example.


### PR DESCRIPTION
- Based on PaperMC/Velocity#1477
- Safer approach: compare config states, fall-back to reconfiguring when not safe/possible (the mentioned PR always skips reconfig, resulting in a bad state when the backend states don't match)
- Enabled under config option `advanced.fast-server-switch` (works properly with `/velocity reload`)