### PR TITLE
Add support for overriding proxy ID with environment variable

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2462,10 +2462,10 @@ public final class VelocityConfiguration implements ProxyConfig {
       this.password = config.get("password");
       this.useSsl = config.getOrElse("use-ssl", true);
 
-      String proxyIdEnv = System.getenv("PROXY_ID");
-      if (proxyIdEnv != null && !proxyIdEnv.isBlank()) {
-        this.proxyId = proxyIdEnv;
-        LOGGER.info("Using proxy ID from environment variable PROXY_ID");
+      String proxyIdOverride = System.getProperty("velocityctd.redis.id");
+      if (proxyIdOverride != null && !proxyIdOverride.isBlank()) {
+        this.proxyId = proxyIdOverride;
+        LOGGER.info("Using proxy ID from system property velocityctd.redis.id");
       } else {
         this.proxyId = config.get("proxy-id");
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -2461,7 +2461,14 @@ public final class VelocityConfiguration implements ProxyConfig {
 
       this.password = config.get("password");
       this.useSsl = config.getOrElse("use-ssl", true);
-      this.proxyId = config.get("proxy-id");
+
+      String proxyIdEnv = System.getenv("PROXY_ID");
+      if (proxyIdEnv != null && !proxyIdEnv.isBlank()) {
+        this.proxyId = proxyIdEnv;
+        LOGGER.info("Using proxy ID from environment variable PROXY_ID");
+      } else {
+        this.proxyId = config.get("proxy-id");
+      }
 
       if (this.proxyId == null || this.proxyId.isEmpty()) {
         this.proxyId = null;

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -456,8 +456,8 @@ use-ssl = false
 # Leave blank if you do not use Redis and is left blank by
 # default to ensure you assign a qualitative proxy ID.
 #
-# You can override this value with setting PROXY_ID
-# environment variable
+# You can override this value with the velocityctd.redis.id
+# system property, e.g. java -Dvelocityctd.redis.id=proxy-1 -jar ...
 #
 # Your server will not start if this is blank and Redis is on.
 proxy-id = ""

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -456,6 +456,9 @@ use-ssl = false
 # Leave blank if you do not use Redis and is left blank by
 # default to ensure you assign a qualitative proxy ID.
 #
+# You can override this value with setting PROXY_ID
+# environment variable
+#
 # Your server will not start if this is blank and Redis is on.
 proxy-id = ""
 


### PR DESCRIPTION
This PR simply adds environment variable support for "redis.proxy-id" option.