### PR TITLE
Quiet Redis depot interruptions during proxy shutdown

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/redis/depot/player/PlayerDepotService.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/depot/player/PlayerDepotService.java
@@ -25,6 +25,7 @@ import com.velocitypowered.api.scheduler.ScheduledTask;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
+import io.lettuce.core.RedisCommandInterruptedException;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -293,11 +294,7 @@ public final class PlayerDepotService extends AbstractDepotService<UUID, PlayerE
    * Updates the total player count by recalculating the number of entries in the depot.
    */
   private void updateTotalPlayerCount() {
-    if (this.redis.isShutdown()) {
-      return;
-    }
-
-    this.totalPlayerCount = this.depot.size();
+    runDepotTick(() -> this.totalPlayerCount = this.depot.size());
   }
 
   /**
@@ -306,32 +303,49 @@ public final class PlayerDepotService extends AbstractDepotService<UUID, PlayerE
    * the server.
    */
   private void syncPlayerEntries() {
+    runDepotTick(() -> {
+      for (ConnectedPlayer player : this.server.getOnlinePlayers()) {
+        if (!player.isFullyConnected()) {
+          continue;
+        }
+
+        if (this.depot.contains(player.getUniqueId())) {
+          continue;
+        }
+
+        this.upsertPlayerEntry(player);
+      }
+
+      for (PlayerEntry playerEntry : this.depot.values()) {
+        if (!playerEntry.getProxyId().equalsIgnoreCase(this.redis.getProxyId())) {
+          continue;
+        }
+
+        if (this.server.getPlayer(playerEntry.getUniqueId()).isPresent()) {
+          continue;
+        }
+
+        playerEntry.remove();
+      }
+    });
+  }
+
+  /**
+   * Runs a periodic Redis depot tick, ignoring command interrupts from task cancellation
+   * during proxy shutdown (the scheduler may interrupt before {@link VelocityRedis#shutdown()}).
+   *
+   * @param tick the depot work to run
+   */
+  private void runDepotTick(@NotNull Runnable tick) {
     if (this.redis.isShutdown()) {
       return;
     }
 
-    for (ConnectedPlayer player : this.server.getOnlinePlayers()) {
-      if (!player.isFullyConnected()) {
-        continue;
-      }
-
-      if (this.depot.contains(player.getUniqueId())) {
-        continue;
-      }
-
-      this.upsertPlayerEntry(player);
-    }
-
-    for (PlayerEntry playerEntry : this.depot.values()) {
-      if (!playerEntry.getProxyId().equalsIgnoreCase(this.redis.getProxyId())) {
-        continue;
-      }
-
-      if (this.server.getPlayer(playerEntry.getUniqueId()).isPresent()) {
-        continue;
-      }
-
-      playerEntry.remove();
+    try {
+      tick.run();
+    } catch (RedisCommandInterruptedException ignored) {
+      // Expected when the scheduler interrupts this task during proxy shutdown.
+      Thread.currentThread().interrupt();
     }
   }
 }

--- a/proxy/src/main/java/com/velocityctd/proxy/redis/depot/proxy/ProxyDepotService.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/redis/depot/proxy/ProxyDepotService.java
@@ -23,6 +23,7 @@ import com.velocityctd.proxy.redis.depot.player.PlayerEntry;
 import com.velocityctd.proxy.redis.provider.LettuceProvider;
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import com.velocitypowered.proxy.plugin.virtual.VelocityVirtualPlugin;
+import io.lettuce.core.RedisCommandInterruptedException;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -153,30 +154,28 @@ public final class ProxyDepotService extends AbstractDepotService<String, ProxyE
    * Called every {@link #HEARTBEAT_INTERVAL} by the scheduler.
    */
   private void publishHeartbeat() {
-    if (this.redis.isShutdown()) {
-      return;
-    }
+    runDepotTick(() -> {
+      String heartbeatKey = this.heartbeatKeyPrefix + this.redis.getProxyId();
 
-    String heartbeatKey = this.heartbeatKeyPrefix + this.redis.getProxyId();
-
-    // Skip the first publish: the key may still hold our own token from a crash within the TTL.
-    if (this.heartbeatPublished) {
-      String owner = this.redis.getProvider().get(heartbeatKey);
-      if (owner != null && !owner.equals(this.instanceId) && this.duplicateWarned.compareAndSet(false, true)) {
-        LOGGER.error("Another proxy is publishing heartbeats under proxy-id '{}'. Every proxy sharing "
-                + "a Redis instance must have a unique proxy-id; running multiple with the same id causes "
-                + "undefined behavior. Fix proxy-id in velocity.toml on the conflicting proxies.",
-                this.redis.getProxyId());
+      // Skip the first publish: the key may still hold our own token from a crash within the TTL.
+      if (this.heartbeatPublished) {
+        String owner = this.redis.getProvider().get(heartbeatKey);
+        if (owner != null && !owner.equals(this.instanceId) && this.duplicateWarned.compareAndSet(false, true)) {
+          LOGGER.error("Another proxy is publishing heartbeats under proxy-id '{}'. Every proxy sharing "
+                  + "a Redis instance must have a unique proxy-id; running multiple with the same id causes "
+                  + "undefined behavior. Fix proxy-id in velocity.toml on the conflicting proxies.",
+                  this.redis.getProxyId());
+        }
       }
-    }
 
-    this.redis.getProvider().setWithExpiry(
-            heartbeatKey,
-            this.instanceId,
-            HEARTBEAT_TTL.toSeconds()
-    );
+      this.redis.getProvider().setWithExpiry(
+              heartbeatKey,
+              this.instanceId,
+              HEARTBEAT_TTL.toSeconds()
+      );
 
-    this.heartbeatPublished = true;
+      this.heartbeatPublished = true;
+    });
   }
 
   /**
@@ -185,20 +184,37 @@ public final class ProxyDepotService extends AbstractDepotService<String, ProxyE
    * Called every {@link #HEARTBEAT_INTERVAL} by the scheduler.
    */
   private void reapDeadProxies() {
+    runDepotTick(() -> {
+      for (String proxyId : this.getAllProxyIds()) {
+        if (proxyId.equalsIgnoreCase(this.redis.getProxyId())) {
+          continue; // Never reap ourselves.
+        }
+
+        if (this.redis.getProvider().existsKey(this.heartbeatKeyPrefix + proxyId)) {
+          continue; // Proxy is alive.
+        }
+
+        reapProxy(proxyId);
+      }
+    });
+  }
+
+  /**
+   * Runs a periodic Redis depot tick, ignoring command interrupts from task cancellation
+   * during proxy shutdown (the scheduler may interrupt before {@link VelocityRedis#shutdown()}).
+   *
+   * @param tick the depot work to run
+   */
+  private void runDepotTick(@NotNull Runnable tick) {
     if (this.redis.isShutdown()) {
       return;
     }
 
-    for (String proxyId : this.getAllProxyIds()) {
-      if (proxyId.equalsIgnoreCase(this.redis.getProxyId())) {
-        continue; // Never reap ourselves.
-      }
-
-      if (this.redis.getProvider().existsKey(this.heartbeatKeyPrefix + proxyId)) {
-        continue; // Proxy is alive.
-      }
-
-      reapProxy(proxyId);
+    try {
+      tick.run();
+    } catch (RedisCommandInterruptedException ignored) {
+      // Expected when the scheduler interrupts this task during proxy shutdown.
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
## Summary
- Redis heartbeat / reaper / player depot ticks can be interrupted while the proxy shuts down
- That produced RedisCommandInterruptedException ERROR spam even on a clean Ctrl+C
- Catch those interrupts in the periodic depot tasks and exit quietly (interrupt flag restored)

## Tests
- Tested same scenario locally with local build. No more error spams on terminal.