### PR TITLE
feat: Add per-forced-host custom MOTD, server icon (favicon), and fallback paths

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -394,6 +394,15 @@ public final class VelocityConfiguration implements ProxyConfig {
             valid = false;
           }
         }
+
+        if (entry.getValue().getFallbackServers() != null) {
+          for (String fallbackServer : entry.getValue().getFallbackServers()) {
+            if (!servers.getBackendServers().containsKey(fallbackServer)) {
+              LOGGER.error("Fallback server '{}' for forced host '{}' does not exist", fallbackServer, entry.getKey());
+              valid = false;
+            }
+          }
+        }
       }
     }
 
@@ -1685,18 +1694,33 @@ public final class VelocityConfiguration implements ProxyConfig {
 
   /**
    * Represents a single forced host entry, containing the list of servers to try
-   * and an optional per-host dynamic fallbacks filter that overrides the global one.
+   * and optional per-host settings such as custom dynamic fallbacks filter, custom MOTD,
+   * custom server icon, and custom fallback path.
    */
   public static final class ForcedHostEntry {
 
     private final List<String> servers;
     private final DynamicFallbackFilter dynamicFallbackFilter;
     private final boolean forcedHostAsFallback;
+    private final @Nullable List<String> fallbackServers;
+    private final @Nullable List<String> motd;
+    private final @Nullable List<String> motdHover;
+    private final @Nullable Favicon favicon;
 
-    private ForcedHostEntry(List<String> servers, DynamicFallbackFilter dynamicFallbackFilter, boolean forcedHostAsFallback) {
+    private ForcedHostEntry(List<String> servers,
+                            @Nullable DynamicFallbackFilter dynamicFallbackFilter,
+                            boolean forcedHostAsFallback,
+                            @Nullable List<String> fallbackServers,
+                            @Nullable List<String> motd,
+                            @Nullable List<String> motdHover,
+                            @Nullable Favicon favicon) {
       this.servers = servers;
       this.dynamicFallbackFilter = dynamicFallbackFilter;
       this.forcedHostAsFallback = forcedHostAsFallback;
+      this.fallbackServers = fallbackServers;
+      this.motd = motd;
+      this.motdHover = motdHover;
+      this.favicon = favicon;
     }
 
     public List<String> getServers() {
@@ -1715,12 +1739,44 @@ public final class VelocityConfiguration implements ProxyConfig {
       return forcedHostAsFallback;
     }
 
+    /**
+     * Returns the custom fallback servers for this forced host, or {@code null} if none configured.
+     */
+    public @Nullable List<String> getFallbackServers() {
+      return fallbackServers;
+    }
+
+    /**
+     * Returns the custom MOTD lines for pings targeting this forced host, or {@code null} if default should be used.
+     */
+    public @Nullable List<String> getMotd() {
+      return motd;
+    }
+
+    /**
+     * Returns the custom MOTD hover tooltip lines for pings targeting this forced host, or {@code null} if default should be used.
+     */
+    public @Nullable List<String> getMotdHover() {
+      return motdHover;
+    }
+
+    /**
+     * Returns the custom server icon (favicon) for pings targeting this forced host, or {@code null} if default should be used.
+     */
+    public @Nullable Favicon getFavicon() {
+      return favicon;
+    }
+
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("servers", servers)
           .add("dynamicFallbackFilter", dynamicFallbackFilter)
           .add("forcedHostAsFallback", forcedHostAsFallback)
+          .add("fallbackServers", fallbackServers)
+          .add("motd", motd)
+          .add("motdHover", motdHover)
+          .add("favicon", favicon)
           .toString();
     }
   }
@@ -1739,17 +1795,17 @@ public final class VelocityConfiguration implements ProxyConfig {
         for (UnmodifiableConfig.Entry entry : config.entrySet()) {
           String key = entry.getKey().toLowerCase(Locale.ROOT);
 
-          if (entry.getValue() instanceof String) {
-            entries.put(key, new ForcedHostEntry(ImmutableList.of(entry.getValue()), null, true));
-          } else if (entry.getValue() instanceof List) {
-            entries.put(key, new ForcedHostEntry(ImmutableList.copyOf((List<String>) entry.getValue()), null, true));
+          if (entry.getValue() instanceof String str) {
+            entries.put(key, new ForcedHostEntry(ImmutableList.of(str), null, true, null, null, null, null));
+          } else if (entry.getValue() instanceof List<?> list) {
+            entries.put(key, new ForcedHostEntry(ImmutableList.copyOf((List<String>) list), null, true, null, null, null, null));
           } else if (entry.getValue() instanceof UnmodifiableConfig tableConfig) {
             Object serversValue = tableConfig.get("servers");
             List<String> servers;
-            if (serversValue instanceof String) {
-              servers = ImmutableList.of((String) serversValue);
-            } else if (serversValue instanceof List) {
-              servers = ImmutableList.copyOf((List<String>) serversValue);
+            if (serversValue instanceof String str) {
+              servers = ImmutableList.of(str);
+            } else if (serversValue instanceof List<?> list) {
+              servers = ImmutableList.copyOf((List<String>) list);
             } else {
               LOGGER.warn("Invalid or missing 'servers' in forced host '{}'!", key);
               continue;
@@ -1760,7 +1816,37 @@ public final class VelocityConfiguration implements ProxyConfig {
             boolean forcedHostAsFallback = tableConfig.getOrElse("forced-host-as-fallback",
                 config.getOrElse("forced-host-as-fallback", true));
 
-            entries.put(key, new ForcedHostEntry(servers, filter, forcedHostAsFallback));
+            List<String> fallbackServers = parseStringList(tableConfig,
+                "fallback-servers", "fallback_servers", "fallback-path", "fallback_path",
+                "fallbacks", "attempt-connection-order");
+            List<String> motd = parseStringList(tableConfig, "motd");
+            List<String> motdHover = parseStringList(tableConfig, "motd-hover", "motd_hover");
+
+            Favicon favicon = null;
+            String iconPathStr = tableConfig.get("icon");
+            if (iconPathStr == null) {
+              iconPathStr = tableConfig.get("server-icon");
+            }
+            if (iconPathStr == null) {
+              iconPathStr = tableConfig.get("server_icon");
+            }
+            if (iconPathStr == null) {
+              iconPathStr = tableConfig.get("favicon");
+            }
+            if (iconPathStr != null && !iconPathStr.isBlank()) {
+              Path iconPath = Path.of(iconPathStr);
+              if (Files.exists(iconPath)) {
+                try {
+                  favicon = Favicon.create(iconPath);
+                } catch (Exception e) {
+                  LOGGER.warn("Unable to load forced host icon '{}' for '{}'", iconPathStr, key, e);
+                }
+              } else {
+                LOGGER.warn("Forced host icon file '{}' for '{}' does not exist", iconPathStr, key);
+              }
+            }
+
+            entries.put(key, new ForcedHostEntry(servers, filter, forcedHostAsFallback, fallbackServers, motd, motdHover, favicon));
           } else {
             LOGGER.warn("Invalid value of type {} in forced hosts!", entry.getValue().getClass());
           }
@@ -1768,6 +1854,18 @@ public final class VelocityConfiguration implements ProxyConfig {
 
         this.entries = ImmutableMap.copyOf(entries);
       }
+    }
+
+    private static @Nullable List<String> parseStringList(UnmodifiableConfig tableConfig, String... keys) {
+      for (String key : keys) {
+        Object val = tableConfig.get(key);
+        if (val instanceof String str) {
+          return ImmutableList.of(str);
+        } else if (val instanceof List<?> list && !list.isEmpty()) {
+          return ImmutableList.copyOf(list.stream().map(Object::toString).toList());
+        }
+      }
+      return null;
     }
 
     private Map<String, List<String>> getForcedHosts() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
@@ -151,8 +151,20 @@ public record FallbackServers(
       return Optional.empty();
     }
 
+    List<String> serversToTry;
+    if (entry.getFallbackServers() != null && !entry.getFallbackServers().isEmpty()) {
+      serversToTry = new ArrayList<>(entry.getServers());
+      for (String fb : entry.getFallbackServers()) {
+        if (!serversToTry.contains(fb)) {
+          serversToTry.add(fb);
+        }
+      }
+    } else {
+      serversToTry = entry.getServers();
+    }
+
     return Optional.of(new FallbackServers(
-        entry.getServers(),
+        serversToTry,
         Optional.ofNullable(entry.getDynamicFallbackFilter())
             .orElseGet(config::getDynamicFallbackFilter),
         virtualHost,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -26,13 +26,17 @@ import com.velocityctd.proxy.util.SamplePlayersPlaceholderResolver;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.server.PingOptions;
 import com.velocitypowered.api.proxy.server.ServerPing;
+import com.velocitypowered.api.util.Favicon;
 import com.velocitypowered.api.util.ModInfo;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.config.PingPassthroughMode;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
+import com.velocitypowered.proxy.config.VelocityConfiguration.ForcedHostEntry;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -60,9 +64,39 @@ public class ServerListPingHandler {
     return clientVersion.lessThan(minimumVersion) || clientVersion.greaterThan(maximumVersion);
   }
 
+  private @Nullable ForcedHostEntry resolveForcedHostEntry(@Nullable VelocityInboundConnection connection) {
+    if (connection == null) {
+      return null;
+    }
+    String vhost = connection.getVirtualHost()
+        .map(InetSocketAddress::getHostString)
+        .map(host -> host.toLowerCase(Locale.ROOT))
+        .orElse(null);
+    if (vhost == null) {
+      return null;
+    }
+    Map<String, ForcedHostEntry> forcedHosts = server.getConfiguration().getForcedHostEntries();
+    ForcedHostEntry exact = forcedHosts.get(vhost);
+    if (exact != null) {
+      return exact;
+    }
+    for (Map.Entry<String, ForcedHostEntry> entry : forcedHosts.entrySet()) {
+      String pattern = entry.getKey().toLowerCase(Locale.ROOT);
+      if (pattern.startsWith("*.") && vhost.endsWith(pattern.substring(1))) {
+        return entry.getValue();
+      }
+    }
+    return null;
+  }
+
   private ServerPing constructLocalPing(ProtocolVersion clientVersion) {
+    return constructLocalPing(clientVersion, null);
+  }
+
+  private ServerPing constructLocalPing(ProtocolVersion clientVersion, @Nullable VelocityInboundConnection connection) {
     VelocityConfiguration configuration = server.getConfiguration();
     boolean outOfRange = displayFallbackPing(clientVersion);
+    VelocityConfiguration.ForcedHostEntry forcedHost = resolveForcedHostEntry(connection);
 
     ProtocolVersion displayVersion =
         (clientVersion == ProtocolVersion.UNKNOWN || outOfRange)
@@ -91,10 +125,22 @@ public class ServerListPingHandler {
 
     SamplePlayersPicker sharedPicker = configuration.isPoolPlayersAcrossSections() ? SamplePlayersPicker.create(server) : null;
 
-    List<String> motd = PlaceholderSubstitutor.substitute(configuration.getMotdLines(), basicResolver,
+    List<String> rawMotd = (forcedHost != null && forcedHost.getMotd() != null && !forcedHost.getMotd().isEmpty())
+        ? forcedHost.getMotd()
+        : configuration.getMotdLines();
+
+    List<String> rawMotdHover = (forcedHost != null && forcedHost.getMotdHover() != null)
+        ? forcedHost.getMotdHover()
+        : configuration.getMotdHoverLines();
+
+    Favicon favicon = (forcedHost != null && forcedHost.getFavicon() != null)
+        ? forcedHost.getFavicon()
+        : configuration.getFavicon().orElse(null);
+
+    List<String> motd = PlaceholderSubstitutor.substitute(rawMotd, basicResolver,
             samplePlayersResolver(sharedPicker, 8, 4, "None", ", "));
 
-    List<String> motdHover = PlaceholderSubstitutor.substitute(configuration.getMotdHoverLines(), basicResolver,
+    List<String> motdHover = PlaceholderSubstitutor.substitute(rawMotdHover, basicResolver,
             samplePlayersResolver(sharedPicker, 12, 1, "", ""));
     if (motdHover.size() == 1 && motdHover.getFirst().isEmpty()) {
       motdHover.clear();
@@ -119,7 +165,7 @@ public class ServerListPingHandler {
             .map(ComponentUtils::parse)
             .reduce((a, b) -> a.appendNewline().append(b))
             .orElseGet(Component::empty),
-        configuration.getFavicon().orElse(null),
+        favicon,
         configuration.isAnnounceForge() ? ModInfo.DEFAULT : null,
         configuration.doesPreventChatReports()
     );
@@ -142,7 +188,7 @@ public class ServerListPingHandler {
                                                                PingPassthroughMode mode, List<String> servers,
                                                                ProtocolVersion responseProtocolVersion,
                                                                String virtualHostStr) {
-    ServerPing fallback = constructLocalPing(connection.getProtocolVersion());
+    ServerPing fallback = constructLocalPing(connection.getProtocolVersion(), connection);
     List<CompletableFuture<ServerPing>> pings = new ArrayList<>();
     for (String s : servers) {
       Optional<VelocityRegisteredServer> rs = server.getServer(s);
@@ -235,7 +281,7 @@ public class ServerListPingHandler {
     PingPassthroughMode passthroughMode = configuration.getPingPassthrough();
 
     if (passthroughMode == PingPassthroughMode.DISABLED) {
-      return CompletableFuture.completedFuture(constructLocalPing(connection.getProtocolVersion()));
+      return CompletableFuture.completedFuture(constructLocalPing(connection.getProtocolVersion(), connection));
     } else {
       FallbackServers fallbackServers = FallbackServers.resolveFallbackServers(server, connection);
 

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -224,8 +224,9 @@ server-aliases = [
 #   "lobby.example.com" = "lobby"
 #   "lobby.example.com" = ["lobby1", "lobby2"]
 #
-# Table format - allows setting per-host options:
-#   "lobby.example.com" = { servers = ["lobby1", "lobby2"], dynamic-fallbacks-filter = "least_populated", forced-host-as-fallback = true }
+# Table format - allows setting per-host options including custom fallback paths, custom MOTD,
+# custom MOTD hover tooltip, and custom server icon (favicon 64x64 PNG):
+#   "lobby.example.com" = { servers = ["lobby1", "lobby2"], fallback-servers = ["lobby-limbo"], motd = ["<#ff3a4c>Custom Lobby MOTD</#ff3a4c>"], motd-hover = ["<gray>Welcome!</gray>"], icon = "server-icon.png", dynamic-fallbacks-filter = "least_populated", forced-host-as-fallback = true }
 #
 "lobby.example.com" = [
     "lobby"
@@ -233,7 +234,7 @@ server-aliases = [
 "factions.example.com" = [
     "factions"
 ]
-# "minigames.example.com" = { servers = ["minigames-limbo", "minigames-1", "minigames-2"], dynamic-fallbacks-filter = "first_available", forced-host-as-fallback = true }
+# "minigames.example.com" = { servers = ["minigames-limbo", "minigames-1", "minigames-2"], fallback-servers = ["lobby"], motd = ["<#ff3a4c>Minigames Network</#ff3a4c>"], icon = "minigames-icon.png", dynamic-fallbacks-filter = "first_available", forced-host-as-fallback = true }
 
 [command-aliases]
 # What commands should have aliases for simpler execution that

--- a/proxy/src/test/java/com/velocitypowered/proxy/config/ForcedHostCustomOptionsTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/config/ForcedHostCustomOptionsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.velocitypowered.api.proxy.InboundConnection;
+import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.connection.util.FallbackServers;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+class ForcedHostCustomOptionsTest {
+
+  @Test
+  void testForcedHostCustomOptionsParsing(@TempDir Path tempDir) throws IOException {
+    Path configFile = tempDir.resolve("velocity.toml");
+    String configContent = """
+        config-version = "2.9"
+        bind = "0.0.0.0:25565"
+
+        [servers]
+        lobby = "127.0.0.1:30066"
+        lobby-fallback = "127.0.0.1:30067"
+        try = ["lobby"]
+
+        [forced-hosts."lobby.example.com"]
+        servers = ["lobby"]
+        fallback-servers = ["lobby-fallback"]
+        motd = ["<red>Custom MOTD</red>"]
+        motd-hover = ["<gray>Hover Line</gray>"]
+
+        [forced-hosts."single.example.com"]
+        servers = ["lobby"]
+        fallback-servers = "lobby-fallback"
+        motd = "<blue>Single Line MOTD</blue>"
+        motd-hover = "<green>Single Hover</green>"
+        """;
+
+    Files.writeString(configFile, configContent);
+
+    VelocityConfiguration config = VelocityConfiguration.read(configFile);
+
+    VelocityConfiguration.ForcedHostEntry entry1 = config.getForcedHostEntries().get("lobby.example.com");
+    assertNotNull(entry1);
+    assertEquals(List.of("lobby"), entry1.getServers());
+    assertEquals(List.of("lobby-fallback"), entry1.getFallbackServers());
+    assertEquals(List.of("<red>Custom MOTD</red>"), entry1.getMotd());
+    assertEquals(List.of("<gray>Hover Line</gray>"), entry1.getMotdHover());
+    assertNull(entry1.getFavicon());
+
+    VelocityConfiguration.ForcedHostEntry entry2 = config.getForcedHostEntries().get("single.example.com");
+    assertNotNull(entry2);
+    assertEquals(List.of("lobby"), entry2.getServers());
+    assertEquals(List.of("lobby-fallback"), entry2.getFallbackServers());
+    assertEquals(List.of("<blue>Single Line MOTD</blue>"), entry2.getMotd());
+    assertEquals(List.of("<green>Single Hover</green>"), entry2.getMotdHover());
+  }
+
+  @Test
+  void testFallbackServersResolution(@TempDir Path tempDir) throws IOException {
+    Path configFile = tempDir.resolve("velocity.toml");
+    String configContent = """
+        config-version = "2.9"
+        bind = "0.0.0.0:25565"
+
+        [servers]
+        lobby = "127.0.0.1:30066"
+        lobby-fallback = "127.0.0.1:30067"
+        limbo = "127.0.0.1:30068"
+        try = ["lobby"]
+
+        [forced-hosts]
+        "lobby.example.com" = { servers = ["lobby"], fallback-servers = ["lobby-fallback", "limbo"] }
+        """;
+
+    Files.writeString(configFile, configContent);
+    VelocityConfiguration config = VelocityConfiguration.read(configFile);
+
+    VelocityServer mockServer = Mockito.mock(VelocityServer.class);
+    Mockito.when(mockServer.getConfiguration()).thenReturn(config);
+
+    InboundConnection mockConnection = Mockito.mock(InboundConnection.class);
+    Mockito.when(mockConnection.getVirtualHost()).thenReturn(Optional.of(new InetSocketAddress("lobby.example.com", 25565)));
+
+    FallbackServers fallbackServers = FallbackServers.resolveFallbackServers(mockServer, mockConnection);
+    assertNotNull(fallbackServers);
+    assertEquals(List.of("lobby", "lobby-fallback", "limbo"), fallbackServers.serversToTry());
+    assertEquals("lobby.example.com", fallbackServers.virtualHost());
+  }
+}


### PR DESCRIPTION
### Summary of Changes

Adds support for per-forced-host custom MOTD, MOTD hover tooltips, server icons (favicon 64x64 PNG), and custom fallback paths when using table configuration syntax in `[forced-hosts]`.

#### Config Options (`default-velocity.toml`)
When defining forced hosts using table format, the following optional parameters are now supported:
- `motd`: Custom MOTD lines for pings targeting this forced host (string or list of strings).
- `motd-hover` / `motd_hover`: Custom MOTD hover tooltip lines for pings targeting this forced host (string or list of strings).
- `icon` / `server-icon` / `favicon`: Path to a 64x64 PNG server icon file for pings targeting this forced host.
- `fallback-servers` / `fallback-path`: Custom ordered fallback servers to attempt if primary `servers` fail or drop connection.

Example:
```toml
[forced-hosts]
"lobby.example.com" = { servers = ["lobby1"], fallback-servers = ["lobby-limbo"], motd = ["<#ff3a4c>Welcome to Lobby</#ff3a4c>"], motd-hover = ["<gray>Click to join</gray>"], icon = "lobby.png" }
```

### Context
This partially addresses some suggested features in issue #1013 at upstream (note: this PR does not address everything; virtualserver functionality remains WIP on our experimental branch).

### Testing
- Built and tested with `./gradlew :velocity-proxy:test`.
- Added unit tests in `ForcedHostCustomOptionsTest.java`.
