### PR TITLE
Add PlayerBackendConfigurationEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerBackendConfigurationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerBackendConfigurationEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player.configuration;
+
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is executed when Velocity starts the backend server's configuration state for a player.
+ *
+ * <p>Velocity will wait for this event before processing backend configuration packets.</p>
+ *
+ * @param player The player whose backend connection is being configured.
+ * @param server The backend server currently configuring the connection.
+ * @since Minecraft 1.20.2
+ */
+@AwaitingEvent
+public record PlayerBackendConfigurationEvent(@NotNull Player player, ServerConnection server) {
+}

--- a/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/connection/fasttransition/FastBackendConfigSessionHandler.java
@@ -17,6 +17,7 @@
 
 package com.velocityctd.proxy.connection.fasttransition;
 
+import com.velocitypowered.api.event.player.configuration.PlayerBackendConfigurationEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
@@ -213,6 +214,17 @@ public class FastBackendConfigSessionHandler implements MinecraftSessionHandler 
           fastTrackable, compatible, clientPlay != null);
       fallbackReconfigure(clientPlay);
     }
+  }
+
+  public CompletableFuture<Void> fireBackendConfigurationEvent() {
+    ConnectedPlayer player = serverConn.getPlayer();
+    return server.getEventManager().fire(new PlayerBackendConfigurationEvent(player, serverConn))
+        .handle((ignored, ex) -> {
+          if (ex != null) {
+            LOGGER.error("Error running fast-transition backend configuration event for {}", player, ex);
+          }
+          return null;
+        });
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -25,6 +25,7 @@ import com.velocitypowered.api.event.player.CookieStoreEvent;
 import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.event.player.ServerResourcePackRemoveEvent;
 import com.velocitypowered.api.event.player.ServerResourcePackSendEvent;
+import com.velocitypowered.api.event.player.configuration.PlayerBackendConfigurationEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.player.ResourcePackInfo;
@@ -120,6 +121,17 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
     this.resultFuture = resultFuture;
     this.state = State.START;
     this.configSnapshot = ConfigStateSnapshot.builder("client-" + serverConn.getServerInfo().getName());
+  }
+
+  public CompletableFuture<Void> fireBackendConfigurationEvent() {
+    ConnectedPlayer player = serverConn.getPlayer();
+    return server.getEventManager().fire(new PlayerBackendConfigurationEvent(player, serverConn))
+        .handle((ignored, ex) -> {
+          if (ex != null) {
+            LOGGER.error("Error running backend configuration event for {}", player, ex);
+          }
+          return null;
+        });
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -166,7 +166,6 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
     if (smc.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_20_2)) {
       smc.setActiveSessionHandler(StateRegistry.PLAY, new TransitionSessionHandler(server, serverConn, resultFuture));
     } else {
-      smc.write(new LoginAcknowledgedPacket());
       ConnectedPlayer player = serverConn.getPlayer();
 
       // Velocity-CTD fast transition: when switching an already-playing client, configure the target
@@ -175,24 +174,33 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
       boolean fastTransition = server.getConfiguration().isFastServerSwitch()
           && player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler;
 
+      smc.setAutoReading(false);
       if (fastTransition) {
-        smc.setActiveSessionHandler(StateRegistry.CONFIG,
-            new FastBackendConfigSessionHandler(server, serverConn, resultFuture));
+        smc.write(new LoginAcknowledgedPacket());
+        FastBackendConfigSessionHandler fastHandler =
+            new FastBackendConfigSessionHandler(server, serverConn, resultFuture);
+        smc.setActiveSessionHandler(StateRegistry.CONFIG, fastHandler);
+        CompletableFuture<Void> backendConfigEvent = fastHandler.fireBackendConfigurationEvent();
         if (player.getClientSettingsPacket() != null) {
           smc.write(player.getClientSettingsPacket());
         }
+        backendConfigEvent.thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
       } else {
-        smc.setActiveSessionHandler(StateRegistry.CONFIG, new ConfigSessionHandler(server, serverConn, resultFuture));
+        smc.write(new LoginAcknowledgedPacket());
+        ConfigSessionHandler configHandler = new ConfigSessionHandler(server, serverConn, resultFuture);
+        smc.setActiveSessionHandler(StateRegistry.CONFIG, configHandler);
+        CompletableFuture<Void> backendConfigEvent = configHandler.fireBackendConfigurationEvent();
         if (player.getClientSettingsPacket() != null) {
           smc.write(player.getClientSettingsPacket());
         }
 
         if (player.getConnection().getActiveSessionHandler() instanceof ClientPlaySessionHandler clientPlaySessionHandler) {
-          smc.setAutoReading(false);
-          clientPlaySessionHandler.doSwitch().thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
+          CompletableFuture.allOf(backendConfigEvent, clientPlaySessionHandler.doSwitch())
+              .thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
         } else {
           // Initial login - the player is already in configuration state.
           server.getEventManager().fireAndForget(new PlayerEnteredConfigurationEvent(player, serverConn));
+          backendConfigEvent.thenRunAsync(() -> smc.setAutoReading(true), smc.eventLoop());
         }
       }
     }


### PR DESCRIPTION
This PR implements the ``PlayerBackendConfigurationEvent``, an event meant to indicate that the proxy begins doing configuration with a backend. its meant as a replacement for the ``PlayerConfigurationEvent`` in the case that the reconfig phase can be skipped, in order to still allow plugins to "do" stuff with the server in the config phase. I have attempted to maintain parity with the original PlayerConfigurationEvent, and for my usecase, it was a drop in replacement for PlayerConfigurationEvent. This event will fire regardless of wheter the reconfig phase is skipped for the player or not, since the reconfig phase with the backend will happen at all times.