### PR TITLE
Add hub-servers option and fix /hub already-connected check (#1011)

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/command/CommandUtils.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/CommandUtils.java
@@ -34,6 +34,7 @@ import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
+import com.velocitypowered.proxy.util.TranslatableMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,9 +49,17 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.translation.Argument;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class CommandUtils {
+
+  private static final Logger LOGGER = LogManager.getLogger(CommandUtils.class);
+  private static final PlainTextComponentSerializer PLAIN_TEXT =
+      PlainTextComponentSerializer.builder().flattener(TranslatableMapper.FLATTENER).build();
 
   private CommandUtils() {
     throw new AssertionError();
@@ -250,12 +259,52 @@ public class CommandUtils {
       throw new IllegalArgumentException("Player is already on target server.");
     }
 
-    if (proxyServer.getConfiguration().getQueue().getNoQueueServers().contains(target.getServerInfo().getName())
-        || !proxyServer.isQueueEnabled()
-        || player.hasPermission("velocity.queue.bypass")) {
-      player.createConnectionRequest(target).connectWithIndication();
-    } else {
+    if (shouldQueue(proxyServer, player, target)) {
       proxyServer.getQueueManager().queue(player, target);
+    } else {
+      player.createConnectionRequest(target).connectWithIndication();
+    }
+  }
+
+  /**
+   * Determines whether a player being sent to `target` should be enqueued for it instead of
+   * connected to it directly.
+   */
+  public static boolean shouldQueue(VelocityServer proxyServer, ConnectedPlayer player, VelocityRegisteredServer target) {
+    return proxyServer.isQueueEnabled()
+        && !proxyServer.getConfiguration().getQueue().getNoQueueServers().contains(target.getServerInfo().getName())
+        && !player.hasPermission("velocity.queue.bypass");
+  }
+
+  /**
+   * Handles a failed attempt to send a player to a server without telling the player about it: logs
+   * the failure and, when the backend turned them away with a configured banned reason, drops them
+   * from every queue. For callers that walk a chain of servers themselves and only want to report
+   * its final outcome; {@code connectWithIndication} does this and more on its own.
+   *
+   * @param reason    the reason the backend gave, or {@code null} if it gave none
+   * @param throwable the failure that aborted the attempt, or {@code null} if it completed normally
+   */
+  public static void reportConnectionFailure(VelocityServer proxyServer, ConnectedPlayer player,
+                                             VelocityRegisteredServer target, @Nullable Component reason,
+                                             @Nullable Throwable throwable) {
+    String targetName = target.getServerInfo().getName();
+    if (throwable != null) {
+      LOGGER.error("{}: unable to connect to server {}", player, targetName, throwable);
+    } else if (proxyServer.getConfiguration().isLogPlayerConnections()) {
+      LOGGER.error("{}: disconnected while connecting to {}: {}", player, targetName,
+          reason == null ? "" : PLAIN_TEXT.serialize(reason));
+    }
+
+    if (reason == null || !proxyServer.isQueueEnabled()) {
+      return;
+    }
+
+    for (String bannedReason : proxyServer.getConfiguration().getQueue().getBannedReason()) {
+      if (ComponentUtils.containsString(reason, bannedReason)) {
+        proxyServer.getQueueManager().removePlayerEntirely(player);
+        break;
+      }
     }
   }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/command/builtin/HubCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/builtin/HubCommand.java
@@ -25,18 +25,23 @@ import com.velocityctd.proxy.command.CommandUtils;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.permission.Tristate;
+import com.velocitypowered.api.proxy.ConnectionRequestBuilder;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.builtin.BuiltinCommandDefinition;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
+import com.velocitypowered.proxy.connection.util.ConnectionMessages;
+import com.velocitypowered.proxy.connection.util.ConnectionRequestResults;
 import com.velocitypowered.proxy.connection.util.FallbackServers;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.GlobalTranslator;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Implements Velocity-CTD's {@code /hub} command.
@@ -75,24 +80,57 @@ public class HubCommand implements BuiltinCommandDefinition {
     VelocityRegisteredServer currentServer = con.getServer();
     requireNonNull(currentServer);
 
-    Deque<String> serversToTry = resolveHubServers(player).calculateRetryDeque(server);
-
-    VelocityRegisteredServer nextServer = serversToTry.stream()
+    List<VelocityRegisteredServer> candidates = resolveHubServers(player).calculateRetryDeque(server).stream()
         .map(server::getServer)
         .flatMap(Optional::stream)
-        .findFirst()
-        .orElse(null);
-    if (nextServer == null) {
+        .distinct()
+        .toList();
+    if (candidates.isEmpty()) {
       player.sendMessage(Component.translatable("velocity.command.no-fallbacks"));
       return 0;
     }
 
-    // Only the server the player would actually be sent to counts as "already connected":
-    // being on any other server of the hub chain is a perfectly good reason to use /hub.
-    if (nextServer.getServerInfo().getName().equals(currentServer.getServerInfo().getName())) {
-      player.sendMessage(Component.translatable("velocity.command.hub.fallback-already-connected")
-              .arguments(Component.text(currentServer.getServerInfo().getName())));
+    // The chain is only walked up to the server the player is already on: every hub they would
+    // rather be on has turned them away, and the one they are on is itself a perfectly good hub.
+    Deque<VelocityRegisteredServer> serversToTry = new ArrayDeque<>();
+    for (VelocityRegisteredServer candidate : candidates) {
+      if (hasSameName(candidate, currentServer)) {
+        break;
+      }
+
+      serversToTry.add(candidate);
+    }
+
+    if (serversToTry.isEmpty()) {
+      // The player is already on the most preferred hub.
+      sendAlreadyConnected(player, currentServer);
       return 0;
+    }
+
+    // Whether the player is on a hub themselves, which decides what they are told once the chain in
+    // front of them is exhausted.
+    boolean currentServerIsHub = serversToTry.size() < candidates.size();
+    connectToFirstAvailable(player, currentServer, serversToTry, currentServerIsHub);
+
+    return SINGLE_SUCCESS;
+  }
+
+  /**
+   * Attempts each remaining hub in order until one accepts the player. Failed hops are logged but
+   * never reported to the player, so that a single {@code /hub} cannot produce a pile of connection
+   * errors; only the outcome of the chain as a whole is.
+   */
+  private void connectToFirstAvailable(ConnectedPlayer player, VelocityRegisteredServer currentServer,
+                                       Deque<VelocityRegisteredServer> serversToTry, boolean currentServerIsHub) {
+    VelocityRegisteredServer nextServer = serversToTry.poll();
+    if (nextServer == null) {
+      if (currentServerIsHub) {
+        sendAlreadyConnected(player, currentServer);
+      } else {
+        player.sendMessage(Component.translatable("velocity.error.no-available-servers"));
+      }
+
+      return;
     }
 
     if (fallbackConnectingTranslationExists(player)) {
@@ -100,16 +138,71 @@ public class HubCommand implements BuiltinCommandDefinition {
               .arguments(Component.text(nextServer.getServerInfo().getName())));
     }
 
-    CommandUtils.sendOrQueue(server, player, nextServer);
+    if (CommandUtils.shouldQueue(server, player, nextServer)) {
+      // The queue owns getting the player onto this server from here on out, retries included.
+      server.getQueueManager().queue(player, nextServer);
+      return;
+    }
 
-    return SINGLE_SUCCESS;
+    player.createConnectionRequest(nextServer).connect().whenComplete((result, throwable) -> {
+      if (shouldTryNextHub(player, nextServer, result, throwable)) {
+        connectToFirstAvailable(player, currentServer, serversToTry, currentServerIsHub);
+      }
+    });
   }
 
   /**
-   * Resolves the servers {@code /hub} should consider for the given player. When
-   * {@code servers.hub-servers} is configured, that list is used with the global dynamic fallback
-   * filter. Otherwise the player's regular fallback chain (forced host or
-   * {@code attempt-connection-order}) is used.
+   * Handles the outcome of a single hub attempt and decides whether the walk continues. It stops
+   * when the player is on their way somewhere, has already been told why they are not, or can no
+   * longer be moved safely.
+   */
+  private boolean shouldTryNextHub(ConnectedPlayer player, VelocityRegisteredServer hub,
+                                   @Nullable ConnectionRequestBuilder.Result result, @Nullable Throwable throwable) {
+    if (throwable == null) {
+      switch (result.getStatus()) {
+        case SUCCESS, CONNECTION_CANCELLED -> {
+          // Either the player made it, or whatever cancelled the request (a plugin, a version
+          // mismatch, a queue restriction) has already explained itself and must be honored.
+          return false;
+        }
+        case ALREADY_CONNECTED -> {
+          player.sendMessage(ConnectionMessages.ALREADY_CONNECTED);
+          return false;
+        }
+        case CONNECTION_IN_PROGRESS -> {
+          player.sendMessage(ConnectionMessages.IN_PROGRESS);
+          return false;
+        }
+        default -> {
+          // SERVER_DISCONNECTED: the backend turned us away, so drop down to the next hub.
+        }
+      }
+    }
+
+    if (result instanceof ConnectionRequestResults.Impl impl && !impl.isSafe()) {
+      // The proxy has already disconnected the player over this, and reported it. The channel close
+      // that follows is asynchronous, so isActive() cannot be relied on to notice.
+      return false;
+    }
+
+    Component reason = result == null ? null : result.getReasonComponent().orElse(null);
+    CommandUtils.reportConnectionFailure(server, player, hub, reason, throwable);
+
+    return player.isActive();
+  }
+
+  private static void sendAlreadyConnected(ConnectedPlayer player, VelocityRegisteredServer currentServer) {
+    player.sendMessage(Component.translatable("velocity.command.hub.fallback-already-connected")
+            .arguments(Component.text(currentServer.getServerInfo().getName())));
+  }
+
+  private static boolean hasSameName(VelocityRegisteredServer first, VelocityRegisteredServer second) {
+    return first.getServerInfo().getName().equalsIgnoreCase(second.getServerInfo().getName());
+  }
+
+  /**
+   * Resolves the servers {@code /hub} should consider for the given player: {@code hub-servers}
+   * when it is configured, and otherwise their regular fallback chain.
    */
   private FallbackServers resolveHubServers(ConnectedPlayer player) {
     List<String> hubServers = server.getConfiguration().getHubServers();

--- a/proxy/src/main/java/com/velocityctd/proxy/command/builtin/HubCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/builtin/HubCommand.java
@@ -32,6 +32,7 @@ import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.util.FallbackServers;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import java.util.Deque;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
@@ -74,13 +75,7 @@ public class HubCommand implements BuiltinCommandDefinition {
     VelocityRegisteredServer currentServer = con.getServer();
     requireNonNull(currentServer);
 
-    Deque<String> serversToTry = FallbackServers.resolveFallbackServers(server.getConfiguration(), player)
-        .calculateRetryDeque(server);
-    if (serversToTry.contains(currentServer.getServerInfo().getName())) {
-      player.sendMessage(Component.translatable("velocity.command.hub.fallback-already-connected")
-              .arguments(Component.text(currentServer.getServerInfo().getName())));
-      return 0;
-    }
+    Deque<String> serversToTry = resolveHubServers(player).calculateRetryDeque(server);
 
     VelocityRegisteredServer nextServer = serversToTry.stream()
         .map(server::getServer)
@@ -92,6 +87,14 @@ public class HubCommand implements BuiltinCommandDefinition {
       return 0;
     }
 
+    // Only the server the player would actually be sent to counts as "already connected":
+    // being on any other server of the hub chain is a perfectly good reason to use /hub.
+    if (nextServer.getServerInfo().getName().equals(currentServer.getServerInfo().getName())) {
+      player.sendMessage(Component.translatable("velocity.command.hub.fallback-already-connected")
+              .arguments(Component.text(currentServer.getServerInfo().getName())));
+      return 0;
+    }
+
     if (fallbackConnectingTranslationExists(player)) {
       player.sendMessage(Component.translatable("velocity.command.hub.fallback-connecting")
               .arguments(Component.text(nextServer.getServerInfo().getName())));
@@ -100,6 +103,25 @@ public class HubCommand implements BuiltinCommandDefinition {
     CommandUtils.sendOrQueue(server, player, nextServer);
 
     return SINGLE_SUCCESS;
+  }
+
+  /**
+   * Resolves the servers {@code /hub} should consider for the given player. When
+   * {@code servers.hub-servers} is configured, that list is used with the global dynamic fallback
+   * filter. Otherwise the player's regular fallback chain (forced host or
+   * {@code attempt-connection-order}) is used.
+   */
+  private FallbackServers resolveHubServers(ConnectedPlayer player) {
+    List<String> hubServers = server.getConfiguration().getHubServers();
+    if (hubServers.isEmpty()) {
+      return FallbackServers.resolveFallbackServers(server.getConfiguration(), player);
+    }
+
+    return new FallbackServers(
+        hubServers,
+        server.getConfiguration().getDynamicFallbackFilter(),
+        null
+    );
   }
 
   private static boolean fallbackConnectingTranslationExists(ConnectedPlayer player) {

--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -158,9 +158,11 @@ public class CtdConfigMigrations {
         ),
         migration(
             "The servers the \"/hub\" command sends players to, in order of preference.\n"
-                + " The same dynamic fallback principles apply here: \"dynamic-fallbacks-filter\" decides\n"
-                + " which of these servers is picked, and players already on the picked server are told\n"
-                + " they are already connected.\n"
+                + " The same dynamic fallback principles apply here: \"dynamic-fallbacks-filter\" decides the\n"
+                + " order, and \"/hub\" walks that order until a server accepts the player, so an unreachable\n"
+                + " hub drops down to the next one instead of failing the command.\n"
+                + " The walk stops at the server the player is already on: they are told they are already\n"
+                + " connected rather than being moved to a hub they like less.\n"
                 + " Leave this empty (the default) to have \"/hub\" use the regular fallback chain instead,\n"
                 + " meaning the forced host matching the player's virtual host, or \"try\" if there is none.",
             "servers.hub-servers",

--- a/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/config/migration/CtdConfigMigrations.java
@@ -156,6 +156,16 @@ public class CtdConfigMigrations {
             "servers.server-aliases",
             List.of("joinqueue", "queue")
         ),
+        migration(
+            "The servers the \"/hub\" command sends players to, in order of preference.\n"
+                + " The same dynamic fallback principles apply here: \"dynamic-fallbacks-filter\" decides\n"
+                + " which of these servers is picked, and players already on the picked server are told\n"
+                + " they are already connected.\n"
+                + " Leave this empty (the default) to have \"/hub\" use the regular fallback chain instead,\n"
+                + " meaning the forced host matching the player's virtual host, or \"try\" if there is none.",
+            "servers.hub-servers",
+            List.of()
+        ),
 
         // [advanced]
         migration(

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/VelocityCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/VelocityCommand.java
@@ -563,9 +563,15 @@ public class VelocityCommand implements BuiltinCommandDefinition {
         connectOrder.add(s);
       }
 
+      JsonArray hubServers = new JsonArray();
+      for (String s : server.getConfiguration().getHubServers()) {
+        hubServers.add(s);
+      }
+
       JsonObject proxyConfig = InformationUtils.collectProxyConfig(server.getConfiguration());
       proxyConfig.add("servers", servers);
       proxyConfig.add("connectOrder", connectOrder);
+      proxyConfig.add("hubServers", hubServers);
       proxyConfig.add("forcedHosts",
               InformationUtils.collectForcedHosts(server.getConfiguration()));
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -23,6 +23,7 @@ import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.annotations.Expose;
 import com.velocityctd.proxy.config.migration.CtdConfigMigrations;
 import com.velocityctd.proxy.util.ComponentUtils;
@@ -58,6 +59,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.apache.logging.log4j.LogManager;
@@ -1555,18 +1557,21 @@ public final class VelocityConfiguration implements ProxyConfig {
   }
 
   /**
-   * Gets the list of servers the {@code /hub} command sends players to.
-   *
-   * <p>If this list is empty, {@code /hub} uses the regular fallback chain
-   * ({@code attempt-connection-order}, or the matching forced host) instead.
-   *
-   * @return the configured hub servers, possibly empty
+   * Gets the servers {@code /hub} sends players to, or an empty list to have it use the regular
+   * fallback chain instead.
    */
   public List<String> getHubServers() {
     return servers.getHubServers();
   }
 
   private static final class Servers {
+
+    /**
+     * The lowercased keys of the {@code [servers]} section that configure the section itself
+     * rather than declaring a backend server.
+     */
+    private static final Set<String> SERVERS_SECTION_SETTINGS = ImmutableSet.of(
+        "try", "dynamic-fallbacks-filter", "server-aliases", "hub-servers");
 
     @Expose
     private Map<String, BackendServerConfig> servers = ImmutableMap.of(
@@ -1604,10 +1609,8 @@ public final class VelocityConfiguration implements ProxyConfig {
     private List<String> serverAliases = List.of("joinqueue", "queue", "server");
 
     /**
-     * The servers the {@code /hub} command sends players to, in order of preference.
-     *
-     * <p>When empty, {@code /hub} falls back to {@code attemptConnectionOrder} (or the forced
-     * host matching the player's virtual host).
+     * The servers {@code /hub} sends players to, in order of preference. When empty, {@code /hub}
+     * uses the player's regular fallback chain instead.
      */
     @Expose
     private List<String> hubServers = ImmutableList.of();
@@ -1623,7 +1626,10 @@ public final class VelocityConfiguration implements ProxyConfig {
         Map<String, String> serverMinimumVersions = new HashMap<>();
         Map<String, String> serverMaximumVersions = new HashMap<>();
         for (UnmodifiableConfig.Entry entry : config.entrySet()) {
-          if (entry.getKey().equalsIgnoreCase("dynamic-fallbacks-filter")) {
+          // The section's own settings are read below. They have to be skipped before the value is
+          // inspected: a setting written as a bare string ("hub-servers = \"lobby\"") would
+          // otherwise be silently registered as a backend server named after the setting.
+          if (SERVERS_SECTION_SETTINGS.contains(entry.getKey().toLowerCase(Locale.ROOT))) {
             continue;
           }
 
@@ -1659,13 +1665,8 @@ public final class VelocityConfiguration implements ProxyConfig {
           } else if (entry.getValue() instanceof String v) {
             servers.put(cleanValue(entry.getKey()), new BackendServerConfig(v));
           } else {
-            if (!entry.getKey().equalsIgnoreCase("try")
-                && !entry.getKey().equalsIgnoreCase("dynamic-fallbacks-filter")
-                && !entry.getKey().equalsIgnoreCase("server-aliases")
-                && !entry.getKey().equalsIgnoreCase("hub-servers")) {
-              throw new IllegalArgumentException(
-                  "Server entry " + entry.getKey() + " is not a server!");
-            }
+            throw new IllegalArgumentException(
+                "Server entry " + entry.getKey() + " is not a server!");
           }
         }
 
@@ -1675,8 +1676,30 @@ public final class VelocityConfiguration implements ProxyConfig {
         this.attemptConnectionOrder = config.getOrElse("try", attemptConnectionOrder).stream().toList();
         this.dynamicFallbackFilter = config.getEnumOrElse("dynamic-fallbacks-filter", DynamicFallbackFilter.FIRST_AVAILABLE);
         this.serverAliases = config.getOrElse("server-aliases", List.of("joinqueue", "queue", "server"));
-        this.hubServers = config.getOrElse("hub-servers", hubServers).stream().toList();
+        this.hubServers = parseServerList("hub-servers", config.get("hub-servers"));
       }
+    }
+
+    /**
+     * Reads a setting that names backend servers, accepting either a single name or a list of them.
+     * Anything that is not a non-empty name is dropped with a warning.
+     */
+    private static List<String> parseServerList(String key, @Nullable Object raw) {
+      if (raw == null) {
+        return ImmutableList.of();
+      }
+
+      List<?> entries = raw instanceof List<?> list ? list : List.of(raw);
+      ImmutableList.Builder<String> names = ImmutableList.builder();
+      for (Object entry : entries) {
+        if (entry instanceof String name && !name.isEmpty()) {
+          names.add(name);
+        } else {
+          LOGGER.warn("Ignoring invalid entry '{}' in \"{}\".", entry, key);
+        }
+      }
+
+      return names.build();
     }
 
     public List<String> getServerAliases() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -385,6 +385,13 @@ public final class VelocityConfiguration implements ProxyConfig {
       }
     }
 
+    for (String s : servers.getHubServers()) {
+      if (!servers.getBackendServers().containsKey(s)) {
+        LOGGER.error("Hub server {} is not registered in your configuration!", s);
+        valid = false;
+      }
+    }
+
     Map<String, ForcedHostEntry> configuredForcedHosts = forcedHosts.getForcedHostEntries();
     if (!configuredForcedHosts.isEmpty()) {
       for (Map.Entry<String, ForcedHostEntry> entry : configuredForcedHosts.entrySet()) {
@@ -1547,6 +1554,18 @@ public final class VelocityConfiguration implements ProxyConfig {
     return servers.getServerAliases();
   }
 
+  /**
+   * Gets the list of servers the {@code /hub} command sends players to.
+   *
+   * <p>If this list is empty, {@code /hub} uses the regular fallback chain
+   * ({@code attempt-connection-order}, or the matching forced host) instead.
+   *
+   * @return the configured hub servers, possibly empty
+   */
+  public List<String> getHubServers() {
+    return servers.getHubServers();
+  }
+
   private static final class Servers {
 
     @Expose
@@ -1583,6 +1602,15 @@ public final class VelocityConfiguration implements ProxyConfig {
      */
     @Expose
     private List<String> serverAliases = List.of("joinqueue", "queue", "server");
+
+    /**
+     * The servers the {@code /hub} command sends players to, in order of preference.
+     *
+     * <p>When empty, {@code /hub} falls back to {@code attemptConnectionOrder} (or the forced
+     * host matching the player's virtual host).
+     */
+    @Expose
+    private List<String> hubServers = ImmutableList.of();
 
     private Servers() {
     }
@@ -1633,7 +1661,8 @@ public final class VelocityConfiguration implements ProxyConfig {
           } else {
             if (!entry.getKey().equalsIgnoreCase("try")
                 && !entry.getKey().equalsIgnoreCase("dynamic-fallbacks-filter")
-                && !entry.getKey().equalsIgnoreCase("server-aliases")) {
+                && !entry.getKey().equalsIgnoreCase("server-aliases")
+                && !entry.getKey().equalsIgnoreCase("hub-servers")) {
               throw new IllegalArgumentException(
                   "Server entry " + entry.getKey() + " is not a server!");
             }
@@ -1646,11 +1675,16 @@ public final class VelocityConfiguration implements ProxyConfig {
         this.attemptConnectionOrder = config.getOrElse("try", attemptConnectionOrder).stream().toList();
         this.dynamicFallbackFilter = config.getEnumOrElse("dynamic-fallbacks-filter", DynamicFallbackFilter.FIRST_AVAILABLE);
         this.serverAliases = config.getOrElse("server-aliases", List.of("joinqueue", "queue", "server"));
+        this.hubServers = config.getOrElse("hub-servers", hubServers).stream().toList();
       }
     }
 
     public List<String> getServerAliases() {
       return serverAliases;
+    }
+
+    public List<String> getHubServers() {
+      return hubServers;
     }
 
     private Map<String, BackendServerConfig> getBackendServers() {
@@ -1693,6 +1727,7 @@ public final class VelocityConfiguration implements ProxyConfig {
           .add("serverMaximumVersions", serverMaximumVersions)
           .add("dynamicFallbackFilter", dynamicFallbackFilter)
           .add("serverAliases", serverAliases)
+          .add("hubServers", hubServers)
           .toString();
     }
   }

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -216,6 +216,14 @@ server-aliases = [
     "queue"
 ]
 
+# The servers the "/hub" command sends players to, in order of preference.
+# The same dynamic fallback principles apply here: "dynamic-fallbacks-filter" decides
+# which of these servers is picked, and players already on the picked server are told
+# they are already connected.
+# Leave this empty (the default) to have "/hub" use the regular fallback chain instead,
+# meaning the forced host matching the player's virtual host, or "try" if there is none.
+hub-servers = []
+
 [forced-hosts]
 # Configure your forced hosts here.
 # Each entry can be specified in two ways:

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -217,9 +217,11 @@ server-aliases = [
 ]
 
 # The servers the "/hub" command sends players to, in order of preference.
-# The same dynamic fallback principles apply here: "dynamic-fallbacks-filter" decides
-# which of these servers is picked, and players already on the picked server are told
-# they are already connected.
+# The same dynamic fallback principles apply here: "dynamic-fallbacks-filter" decides the
+# order, and "/hub" walks that order until a server accepts the player, so an unreachable
+# hub drops down to the next one instead of failing the command.
+# The walk stops at the server the player is already on: they are told they are already
+# connected rather than being moved to a hub they like less.
 # Leave this empty (the default) to have "/hub" use the regular fallback chain instead,
 # meaning the forced host matching the player's virtual host, or "try" if there is none.
 hub-servers = []


### PR DESCRIPTION
Closes #1011.

Adds:
```toml
# The servers the "/hub" command sends players to, in order of preference.
# The same dynamic fallback principles apply here: "dynamic-fallbacks-filter" decides
# which of these servers is picked, and players already on the picked server are told
# they are already connected.
# Leave this empty (the default) to have "/hub" use the regular fallback chain instead,
# meaning the forced host matching the player's virtual host, or "try" if there is none.
hub-servers = []
```