### PR TITLE
Allow Forced Hosts to specify Session Servers

### DIFF
--- a/proxy/src/main/java/com/velocityctd/proxy/command/builtin/HubCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/builtin/HubCommand.java
@@ -74,7 +74,8 @@ public class HubCommand implements BuiltinCommandDefinition {
     VelocityRegisteredServer currentServer = con.getServer();
     requireNonNull(currentServer);
 
-    Deque<String> serversToTry = FallbackServers.resolveFallbackServers(server, player).calculateRetryDeque(server);
+    Deque<String> serversToTry = FallbackServers.resolveFallbackServers(server.getConfiguration(), player)
+        .calculateRetryDeque(server);
     if (serversToTry.contains(currentServer.getServerInfo().getName())) {
       player.sendMessage(Component.translatable("velocity.command.hub.fallback-already-connected")
               .arguments(Component.text(currentServer.getServerInfo().getName())));

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -1704,11 +1704,13 @@ public final class VelocityConfiguration implements ProxyConfig {
     private final List<String> servers;
     private final DynamicFallbackFilter dynamicFallbackFilter;
     private final boolean forcedHostAsFallback;
+    private final String sessionServer;
 
-    private ForcedHostEntry(List<String> servers, DynamicFallbackFilter dynamicFallbackFilter, boolean forcedHostAsFallback) {
+    private ForcedHostEntry(List<String> servers, DynamicFallbackFilter dynamicFallbackFilter, boolean forcedHostAsFallback, String sessionServer) {
       this.servers = servers;
       this.dynamicFallbackFilter = dynamicFallbackFilter;
       this.forcedHostAsFallback = forcedHostAsFallback;
+      this.sessionServer = sessionServer;
     }
 
     public List<String> getServers() {
@@ -1727,12 +1729,22 @@ public final class VelocityConfiguration implements ProxyConfig {
       return forcedHostAsFallback;
     }
 
+    /**
+     * Determines the Mojang Compatible Session Server URL {@code hasJoined} for this session.
+     *
+     * @return base url, no query parameters.
+     */
+    public @Nullable String getSessionServer() {
+      return sessionServer;
+    }
+
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("servers", servers)
           .add("dynamicFallbackFilter", dynamicFallbackFilter)
           .add("forcedHostAsFallback", forcedHostAsFallback)
+          .add("sessionServer", sessionServer)
           .toString();
     }
   }
@@ -1752,9 +1764,9 @@ public final class VelocityConfiguration implements ProxyConfig {
           String key = entry.getKey().toLowerCase(Locale.ROOT);
 
           if (entry.getValue() instanceof String) {
-            entries.put(key, new ForcedHostEntry(ImmutableList.of(entry.getValue()), null, true));
+            entries.put(key, new ForcedHostEntry(ImmutableList.of(entry.getValue()), null, true, null));
           } else if (entry.getValue() instanceof List) {
-            entries.put(key, new ForcedHostEntry(ImmutableList.copyOf((List<String>) entry.getValue()), null, true));
+            entries.put(key, new ForcedHostEntry(ImmutableList.copyOf((List<String>) entry.getValue()), null, true, null));
           } else if (entry.getValue() instanceof UnmodifiableConfig tableConfig) {
             Object serversValue = tableConfig.get("servers");
             List<String> servers;
@@ -1772,7 +1784,9 @@ public final class VelocityConfiguration implements ProxyConfig {
             boolean forcedHostAsFallback = tableConfig.getOrElse("forced-host-as-fallback",
                 config.getOrElse("forced-host-as-fallback", true));
 
-            entries.put(key, new ForcedHostEntry(servers, filter, forcedHostAsFallback));
+            String sessionServer = tableConfig.get("session-server");
+
+            entries.put(key, new ForcedHostEntry(servers, filter, forcedHostAsFallback, sessionServer));
           } else {
             LOGGER.warn("Invalid value of type {} in forced hosts!", entry.getValue().getClass());
           }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -2223,7 +2223,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     private final Deque<String> serversToTry;
 
     private ServerRetrySession() {
-      serversToTry = FallbackServers.resolveFallbackServers(server, ConnectedPlayer.this).calculateRetryDeque(server);
+      serversToTry = FallbackServers.resolveFallbackServers(server.getConfiguration(), ConnectedPlayer.this)
+          .calculateRetryDeque(server);
     }
 
     /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -74,12 +74,12 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-  /**
-   * Server-Wide Session Server URL. Can be overriden by {@link com.velocitypowered.proxy.config.VelocityConfiguration.ForcedHostEntry}.
-   */
+  private static final String MOJANG_HASJOINED_GET_PARAMS = "?username=%s&serverId=%s";
+
   private static final String MOJANG_HASJOINED_URL =
       System.getProperty("mojang.sessionserver",
-              "https://sessionserver.mojang.com/session/minecraft/hasJoined");
+              "https://sessionserver.mojang.com/session/minecraft/hasJoined")
+          .concat(MOJANG_HASJOINED_GET_PARAMS);
 
   private final VelocityServer server;
 
@@ -111,6 +111,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
   private String resolveHasJoinedBaseUrl() {
     return FallbackServers.getForcedHostEntry(server.getConfiguration(), inbound)
         .map(VelocityConfiguration.ForcedHostEntry::getSessionServer)
+        .map(baseUrl -> baseUrl.concat(MOJANG_HASJOINED_GET_PARAMS))
         .orElse(MOJANG_HASJOINED_URL);
   }
 
@@ -257,8 +258,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
       String serverId = generateServerId(decryptedSharedSecret, serverKeyPair.getPublic());
       String playerIp = ((InetSocketAddress) mcConnection.getRemoteAddress()).getHostString();
-      String sessionServer = resolveHasJoinedBaseUrl();
-      String url = String.format(sessionServer.concat("?username=%s&serverId=%s"), urlFormParameterEscaper().escape(login.getUsername()), serverId);
+      String url = String.format(resolveHasJoinedBaseUrl(), urlFormParameterEscaper().escape(login.getUsername()), serverId);
 
       if (server.getConfiguration().shouldPreventClientProxyConnections()) {
         url += "&ip=" + urlFormParameterEscaper().escape(playerIp);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -32,6 +32,7 @@ import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackTransfer;
@@ -53,7 +54,6 @@ import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -109,8 +109,9 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
   }
 
   private String resolveHasJoinedBaseUrl() {
-    String sessionServer = FallbackServers.resolveFallbackServers(server, inbound).sessionServer();
-    return Objects.requireNonNullElse(sessionServer, MOJANG_HASJOINED_URL);
+    return FallbackServers.getForcedHostEntry(server.getConfiguration(), inbound)
+        .map(VelocityConfiguration.ForcedHostEntry::getSessionServer)
+        .orElse(MOJANG_HASJOINED_URL);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -35,6 +35,7 @@ import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackTransfer;
+import com.velocitypowered.proxy.connection.util.FallbackServers;
 import com.velocitypowered.proxy.crypto.IdentifiedKeyImpl;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
@@ -52,6 +53,7 @@ import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -72,10 +74,12 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
+  /**
+   * Server-Wide Session Server URL. Can be overriden by {@link com.velocitypowered.proxy.config.VelocityConfiguration.ForcedHostEntry}.
+   */
   private static final String MOJANG_HASJOINED_URL =
       System.getProperty("mojang.sessionserver",
-              "https://sessionserver.mojang.com/session/minecraft/hasJoined")
-          .concat("?username=%s&serverId=%s");
+              "https://sessionserver.mojang.com/session/minecraft/hasJoined");
 
   private final VelocityServer server;
 
@@ -102,6 +106,11 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
     this.inbound = Preconditions.checkNotNull(inbound, "inbound");
     this.forceKeyAuthentication = VelocityProperties.readBoolean(
         "auth.forceSecureProfiles", server.getConfiguration().isForceKeyAuthentication());
+  }
+
+  private String resolveHasJoinedBaseUrl() {
+    String sessionServer = FallbackServers.resolveFallbackServers(server, inbound).sessionServer();
+    return Objects.requireNonNullElse(sessionServer, MOJANG_HASJOINED_URL);
   }
 
   @Override
@@ -247,7 +256,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
       String serverId = generateServerId(decryptedSharedSecret, serverKeyPair.getPublic());
       String playerIp = ((InetSocketAddress) mcConnection.getRemoteAddress()).getHostString();
-      String url = String.format(MOJANG_HASJOINED_URL, urlFormParameterEscaper().escape(login.getUsername()), serverId);
+      String sessionServer = resolveHasJoinedBaseUrl();
+      String url = String.format(sessionServer.concat("?username=%s&serverId=%s"), urlFormParameterEscaper().escape(login.getUsername()), serverId);
 
       if (server.getConfiguration().shouldPreventClientProxyConnections()) {
         url += "&ip=" + urlFormParameterEscaper().escape(playerIp);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -108,7 +108,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
         "auth.forceSecureProfiles", server.getConfiguration().isForceKeyAuthentication());
   }
 
-  private String resolveHasJoinedBaseUrl() {
+  private String resolveHasJoinedUrl() {
     return FallbackServers.getForcedHostEntry(server.getConfiguration(), inbound)
         .map(VelocityConfiguration.ForcedHostEntry::getSessionServer)
         .map(baseUrl -> baseUrl.concat(MOJANG_HASJOINED_GET_PARAMS))
@@ -258,7 +258,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
       String serverId = generateServerId(decryptedSharedSecret, serverKeyPair.getPublic());
       String playerIp = ((InetSocketAddress) mcConnection.getRemoteAddress()).getHostString();
-      String url = String.format(resolveHasJoinedBaseUrl(), urlFormParameterEscaper().escape(login.getUsername()), serverId);
+      String url = String.format(resolveHasJoinedUrl(), urlFormParameterEscaper().escape(login.getUsername()), serverId);
 
       if (server.getConfiguration().shouldPreventClientProxyConnections()) {
         url += "&ip=" + urlFormParameterEscaper().escape(playerIp);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
@@ -39,22 +39,22 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Holds the resolved fallback server configuration for an inbound connection, including the ordered
  * list of backend servers to try, the applicable dynamic fallback filter, the connection's virtual
- * host, and the forced-host pattern that was matched (if any).
+ * host, and the session server to authenticate against (if any).
  *
- * <p>Use {@link #resolveFallbackServers(VelocityServer, InboundConnection)} to obtain an instance.
+ * <p>Use {@link #resolveFallbackServers(VelocityConfiguration, InboundConnection)} to obtain an
+ * instance.
  *
  * @param serversToTry               the ordered list of backend server names to attempt
  * @param dynamicFallbackFilter      the dynamic fallback filter to apply when selecting a server
  * @param virtualHost                the lowercase virtual host from the connection, or {@code null}
  *                                   if none could be found
- * @param matchedVirtualHostPattern  the forced-host pattern (exact or wildcard) that was matched,
- *                                   or {@code null} if the default connection order is used
+ * @param sessionServer              the {@code hasJoined} base URL from the matched forced host, or
+ *                                   {@code null} if the global one should be used
  */
 public record FallbackServers(
     @NotNull List<String> serversToTry,
     @NotNull DynamicFallbackFilter dynamicFallbackFilter,
     @Nullable String virtualHost,
-    @Nullable String matchedVirtualHostPattern,
     @Nullable String sessionServer
 ) {
 
@@ -115,29 +115,41 @@ public record FallbackServers(
     return result;
   }
 
+  public static Optional<ForcedHostEntry> getForcedHostEntry(VelocityConfiguration config, @Nullable InboundConnection connection) {
+    if (connection == null) {
+      return Optional.empty();
+    }
+
+    return getForcedHostEntry(config, normalizedVirtualHost(connection));
+  }
+
   /**
    * Looks up a forced-host entry for the given {@code virtualHost}, trying an exact
    * case-insensitive match first, then a wildcard match (e.g. {@code *.example.com}).
    *
-   * @return the matching {@link FallbackServers}, or {@link Optional#empty()} if no rule matches
-   *     (or the matched rule opted out of fallback behavior)
+   * @return the matching {@link ForcedHostEntry}.
    */
-  private static Optional<FallbackServers> getForcedHostFallbacks(VelocityConfiguration config, String virtualHost) {
+  private static Optional<ForcedHostEntry> getForcedHostEntry(VelocityConfiguration config, String virtualHost) {
     Map<String, ForcedHostEntry> forcedHosts = config.getForcedHostEntries();
     ForcedHostEntry exactMatch = forcedHosts.get(virtualHost);
     if (exactMatch != null) {
-      return forcedHostFallbacks(config, virtualHost, virtualHost, exactMatch);
+      return Optional.of(exactMatch);
     }
 
     // Check for wildcard ("*.example.com" matches "anything.example.com")
     for (Map.Entry<String, ForcedHostEntry> entry : forcedHosts.entrySet()) {
       String pattern = entry.getKey().toLowerCase(Locale.ROOT);
       if (pattern.startsWith("*.") && virtualHost.endsWith(pattern.substring(1))) {
-        return forcedHostFallbacks(config, virtualHost, entry.getKey(), entry.getValue());
+        return Optional.of(entry.getValue());
       }
     }
 
     return Optional.empty();
+  }
+
+  private static Optional<FallbackServers> getForcedHostFallbacks(VelocityConfiguration config, String virtualHost) {
+    return getForcedHostEntry(config, virtualHost)
+        .flatMap(entry -> forcedHostFallbacks(config, virtualHost, entry));
   }
 
   /**
@@ -147,7 +159,7 @@ public record FallbackServers(
    * the global {@code attempt-connection-order}.
    */
   private static Optional<FallbackServers> forcedHostFallbacks(VelocityConfiguration config,
-                                                               String virtualHost, String pattern, ForcedHostEntry entry) {
+                                                               String virtualHost, ForcedHostEntry entry) {
     if (!entry.isForcedHostAsFallback()) {
       return Optional.empty();
     }
@@ -157,7 +169,6 @@ public record FallbackServers(
         Optional.ofNullable(entry.getDynamicFallbackFilter())
             .orElseGet(config::getDynamicFallbackFilter),
         virtualHost,
-        pattern.toLowerCase(Locale.ROOT),
         entry.getSessionServer()
     ));
   }
@@ -168,31 +179,35 @@ public record FallbackServers(
    * <p>If the connection supplies a virtual host that matches a forced-host rule (exact or
    * wildcard), the servers and filter from that rule are used. Otherwise, the global
    * {@code attempt-connection-order} and dynamic fallback filter from the proxy configuration
-   * are used, with {@link #matchedVirtualHostPattern()} left as {@code null}.
+   * are used.
    *
-   * @param server     the Velocity server instance providing configuration access
+   * @param config     the active configuration
    * @param connection the inbound connection whose virtual host is used for forced-host resolution
    * @return the resolved {@link FallbackServers} for this connection
    */
-  public static FallbackServers resolveFallbackServers(VelocityServer server, InboundConnection connection) {
-    String virtualHost = connection.getVirtualHost()
-        .map(InetSocketAddress::getHostString)
-        .map(host -> host.toLowerCase(Locale.ROOT))
-        .orElse(null);
+  public static FallbackServers resolveFallbackServers(VelocityConfiguration config, InboundConnection connection) {
+    String virtualHost = normalizedVirtualHost(connection);
 
     if (virtualHost != null) {
-      FallbackServers fromVirtualHost = getForcedHostFallbacks(server.getConfiguration(), virtualHost).orElse(null);
+      FallbackServers fromVirtualHost = getForcedHostFallbacks(config, virtualHost).orElse(null);
       if (fromVirtualHost != null) {
         return fromVirtualHost;
       }
     }
 
     return new FallbackServers(
-        server.getConfiguration().getAttemptConnectionOrder(),
-        server.getConfiguration().getDynamicFallbackFilter(),
+        config.getAttemptConnectionOrder(),
+        config.getDynamicFallbackFilter(),
         virtualHost,
-        null,
         null
     );
+  }
+
+  @Nullable
+  private static String normalizedVirtualHost(InboundConnection connection) {
+    return connection.getVirtualHost()
+        .map(InetSocketAddress::getHostString)
+        .map(host -> host.toLowerCase(Locale.ROOT))
+        .orElse(null);
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
@@ -54,7 +54,8 @@ public record FallbackServers(
     @NotNull List<String> serversToTry,
     @NotNull DynamicFallbackFilter dynamicFallbackFilter,
     @Nullable String virtualHost,
-    @Nullable String matchedVirtualHostPattern
+    @Nullable String matchedVirtualHostPattern,
+    @Nullable String sessionServer
 ) {
 
   /**
@@ -156,7 +157,8 @@ public record FallbackServers(
         Optional.ofNullable(entry.getDynamicFallbackFilter())
             .orElseGet(config::getDynamicFallbackFilter),
         virtualHost,
-        pattern.toLowerCase(Locale.ROOT)
+        pattern.toLowerCase(Locale.ROOT),
+        entry.getSessionServer()
     ));
   }
 
@@ -189,6 +191,7 @@ public record FallbackServers(
         server.getConfiguration().getAttemptConnectionOrder(),
         server.getConfiguration().getDynamicFallbackFilter(),
         virtualHost,
+        null,
         null
     );
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/FallbackServers.java
@@ -38,8 +38,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Holds the resolved fallback server configuration for an inbound connection, including the ordered
- * list of backend servers to try, the applicable dynamic fallback filter, the connection's virtual
- * host, and the session server to authenticate against (if any).
+ * list of backend servers to try, the applicable dynamic fallback filter, and the connection's
+ * virtual host.
  *
  * <p>Use {@link #resolveFallbackServers(VelocityConfiguration, InboundConnection)} to obtain an
  * instance.
@@ -48,14 +48,11 @@ import org.jetbrains.annotations.Nullable;
  * @param dynamicFallbackFilter      the dynamic fallback filter to apply when selecting a server
  * @param virtualHost                the lowercase virtual host from the connection, or {@code null}
  *                                   if none could be found
- * @param sessionServer              the {@code hasJoined} base URL from the matched forced host, or
- *                                   {@code null} if the global one should be used
  */
 public record FallbackServers(
     @NotNull List<String> serversToTry,
     @NotNull DynamicFallbackFilter dynamicFallbackFilter,
-    @Nullable String virtualHost,
-    @Nullable String sessionServer
+    @Nullable String virtualHost
 ) {
 
   /**
@@ -168,8 +165,7 @@ public record FallbackServers(
         entry.getServers(),
         Optional.ofNullable(entry.getDynamicFallbackFilter())
             .orElseGet(config::getDynamicFallbackFilter),
-        virtualHost,
-        entry.getSessionServer()
+        virtualHost
     ));
   }
 
@@ -198,8 +194,7 @@ public record FallbackServers(
     return new FallbackServers(
         config.getAttemptConnectionOrder(),
         config.getDynamicFallbackFilter(),
-        virtualHost,
-        null
+        virtualHost
     );
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -237,7 +237,7 @@ public class ServerListPingHandler {
     if (passthroughMode == PingPassthroughMode.DISABLED) {
       return CompletableFuture.completedFuture(constructLocalPing(connection.getProtocolVersion()));
     } else {
-      FallbackServers fallbackServers = FallbackServers.resolveFallbackServers(server, connection);
+      FallbackServers fallbackServers = FallbackServers.resolveFallbackServers(server.getConfiguration(), connection);
 
       return attemptPingPassthrough(connection, passthroughMode, fallbackServers.serversToTry(),
           shownVersion, fallbackServers.virtualHost());

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -229,7 +229,7 @@ server-aliases = [
 #   "lobby.example.com" = ["lobby1", "lobby2"]
 #
 # Table format - allows setting per-host options:
-#   "lobby.example.com" = { servers = ["lobby1", "lobby2"], dynamic-fallbacks-filter = "least_populated", forced-host-as-fallback = true }
+#   "lobby.example.com" = { servers = ["lobby1", "lobby2"], dynamic-fallbacks-filter = "least_populated", forced-host-as-fallback = true, session-server = "https://sessionserver.mojang.com/session/minecraft/hasJoined" }
 #
 "lobby.example.com" = [
     "lobby"


### PR DESCRIPTION
This pull request adds a `session-server` option in the table format of forced hosts. It allows you to integrate MineHut support, or alternative session servers without running a second proxy.

Addresses: [Issue 1031](https://github.com/GemstoneGG/Velocity-CTD/issues/1031)