### PR TITLE
Add server display IDs and hidden list support

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/config/BackendServerConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/BackendServerConfig.java
@@ -25,26 +25,47 @@ import org.jspecify.annotations.Nullable;
  * Additionally, if the forwarding mode is null it means that the server is using the
  * "player-info-forwarding-mode", set in the configuration.</p>
  *
- * @param address        the hostname or address of the backend server
- * @param forwardingMode the forwarding mode to use when forwarding player information
- *                       to this backend server
+ * @param address              the hostname or address of the backend server
+ * @param forwardingMode       the forwarding mode to use when forwarding player information
+ *                             to this backend server
+ * @param displayName          the cosmetic name shown to players in place of the server's id,
+ *                             or {@code null} to show the id as-is
+ * @param customId             an additional identifier players may use in commands to refer to
+ *                             this server, or {@code null} for none
+ * @param hiddenFromServerList whether to hide this server from player-facing listings and
+ *                             tab-completions
  * @since 3.4.0
  * @see PlayerInfoForwarding
  * @see com.velocitypowered.api.proxy.server.ServerInfo#ServerInfo(String, java.net.InetSocketAddress,
  *     PlayerInfoForwarding)
  */
 @NullMarked
-public record BackendServerConfig(String address, @Nullable PlayerInfoForwarding forwardingMode) {
+public record BackendServerConfig(String address, @Nullable PlayerInfoForwarding forwardingMode,
+    @Nullable String displayName, @Nullable String customId, boolean hiddenFromServerList) {
+
+  /**
+   * Creates a new {@link BackendServerConfig}.
+   *
+   * @param address              the hostname or address of the backend server
+   * @param forwardingMode       the forwarding mode for this backend server
+   * @param displayName          the cosmetic name shown to players, or {@code null}
+   * @param customId             an additional identifier players may use in commands, or {@code null}
+   * @param hiddenFromServerList whether to hide this server from player-facing listings
+   * @throws NullPointerException if {@code address} is null
+   */
+  public BackendServerConfig {
+    requireNonNull(address);
+  }
 
   /**
    * Creates a new {@link BackendServerConfig}.
    *
    * @param address        the hostname or address of the backend server
    * @param forwardingMode the forwarding mode for this backend server
-   * @throws NullPointerException if {@code address} or {@code forwardingMode} is null
+   * @throws NullPointerException if {@code address} is null
    */
-  public BackendServerConfig {
-    requireNonNull(address);
+  public BackendServerConfig(String address, @Nullable PlayerInfoForwarding forwardingMode) {
+    this(address, forwardingMode, null, null, false);
   }
 
   /**
@@ -54,6 +75,6 @@ public record BackendServerConfig(String address, @Nullable PlayerInfoForwarding
    * @throws NullPointerException if {@code address} is null
    */
   public BackendServerConfig(String address) {
-    this(address, null);
+    this(address, null, null, null, false);
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/server/ServerInfo.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/ServerInfo.java
@@ -36,6 +36,47 @@ public final class ServerInfo implements Comparable<ServerInfo> {
   private final PlayerInfoForwarding forwardingMode;
 
   /**
+   * A cosmetic name shown to players in place of {@link #name} wherever the server is
+   * displayed. {@code null} means the server's {@link #name} is shown as-is.
+   */
+  @Nullable
+  private final String displayName;
+
+  /**
+   * An additional identifier players may use in commands (such as {@code /server}) to refer to
+   * this server, in addition to its {@link #name}. {@code null} means no alias is configured.
+   */
+  @Nullable
+  private final String customId;
+
+  /**
+   * Whether this server should be hidden from player-facing server listings and tab-completions.
+   * Hidden servers remain fully functional for queues, admin commands, and direct connections.
+   */
+  private final boolean hiddenFromServerList;
+
+  /**
+   * Creates a new ServerInfo object.
+   *
+   * @param name the name for the server
+   * @param address the address of the server to connect to
+   * @param forwardingMode the server info forwarding mode, or {@code null} if the mode from the config should be used
+   * @param displayName the cosmetic name shown to players, or {@code null} to display {@code name}
+   * @param customId an additional identifier players may use in commands, or {@code null} for none
+   * @param hiddenFromServerList whether to hide this server from player-facing listings and tab-completions
+   * @since 3.4.0
+   */
+  public ServerInfo(String name, InetSocketAddress address, @Nullable PlayerInfoForwarding forwardingMode,
+      @Nullable String displayName, @Nullable String customId, boolean hiddenFromServerList) {
+    this.name = Preconditions.checkNotNull(name, "name");
+    this.address = Preconditions.checkNotNull(address, "address");
+    this.forwardingMode = forwardingMode;
+    this.displayName = displayName;
+    this.customId = customId;
+    this.hiddenFromServerList = hiddenFromServerList;
+  }
+
+  /**
    * Creates a new ServerInfo object.
    *
    * @param name the name for the server
@@ -44,9 +85,7 @@ public final class ServerInfo implements Comparable<ServerInfo> {
    * @since 3.4.0
    */
   public ServerInfo(String name, InetSocketAddress address, @Nullable PlayerInfoForwarding forwardingMode) {
-    this.name = Preconditions.checkNotNull(name, "name");
-    this.address = Preconditions.checkNotNull(address, "address");
-    this.forwardingMode = forwardingMode;
+    this(name, address, forwardingMode, null, null, false);
   }
 
   /**
@@ -56,9 +95,7 @@ public final class ServerInfo implements Comparable<ServerInfo> {
    * @param address the address of the server to connect to
    */
   public ServerInfo(String name, InetSocketAddress address) {
-    this.name = Preconditions.checkNotNull(name, "name");
-    this.address = Preconditions.checkNotNull(address, "address");
-    this.forwardingMode = null;
+    this(name, address, null, null, null, false);
   }
 
   /**
@@ -68,6 +105,39 @@ public final class ServerInfo implements Comparable<ServerInfo> {
    */
   public String getName() {
     return name;
+  }
+
+  /**
+   * Gets the cosmetic name that should be shown to players in place of {@link #getName()}.
+   *
+   * <p>If no display name is configured, this returns {@link #getName()} so callers can always
+   * use this method when rendering a server name for players.</p>
+   *
+   * @return the display name, never {@code null}
+   */
+  public String getDisplayName() {
+    return displayName != null ? displayName : name;
+  }
+
+  /**
+   * Gets the additional identifier players may use in commands to refer to this server, if any.
+   *
+   * @return the custom identifier, or {@code null} if none is configured
+   */
+  @Nullable
+  public String getCustomId() {
+    return customId;
+  }
+
+  /**
+   * Returns whether this server should be hidden from player-facing server listings and
+   * tab-completions. Hidden servers remain reachable by name and usable by queues and admin
+   * commands.
+   *
+   * @return {@code true} if the server should be hidden from player-facing listings
+   */
+  public boolean isHiddenFromServerList() {
+    return hiddenFromServerList;
   }
 
   /**
@@ -96,6 +166,9 @@ public final class ServerInfo implements Comparable<ServerInfo> {
         + "name='" + name + '\''
         + ", address=" + address
         + ", forwarding=" + forwardingMode
+        + ", displayName='" + displayName + '\''
+        + ", customId='" + customId + '\''
+        + ", hiddenFromServerList=" + hiddenFromServerList
         + '}';
   }
 

--- a/proxy/src/main/java/com/velocityctd/proxy/command/CommandUtils.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/CommandUtils.java
@@ -28,6 +28,7 @@ import com.velocityctd.api.queue.QueueState;
 import com.velocityctd.proxy.util.ComponentUtils;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.permission.Tristate;
+import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.builtin.CommandMessages;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
@@ -43,7 +44,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.translation.Argument;
@@ -71,6 +71,25 @@ public class CommandUtils {
   public static SuggestionProvider<CommandSource> suggestServer(VelocityServer server, String argName,
                                                                 boolean allowNonQueueable, boolean performPermissionCheck,
                                                                 String... magicServers) {
+    return suggestServer(server, argName, allowNonQueueable, performPermissionCheck, true, magicServers);
+  }
+
+  /**
+   * Generates a suggestion provider to complete the name of a server, optionally excluding servers
+   * marked {@code hidden-from-server-list}.
+   *
+   * @param server the proxy server
+   * @param argName the name of the string argument to complete
+   * @param allowNonQueueable whether to suggest a server if the server has queueing disabled
+   * @param performPermissionCheck whether to perform permission checks before including a server as a suggestion
+   * @param includeHidden whether to include servers marked {@code hidden-from-server-list}. Admin
+   *                      commands should pass {@code true}; player-facing listings {@code false}.
+   * @param magicServers "magic servers" to add, if any. useful for including an "all" argument option.
+   * @return a suggestion provider that completes a server name
+   */
+  public static SuggestionProvider<CommandSource> suggestServer(VelocityServer server, String argName,
+                                                                boolean allowNonQueueable, boolean performPermissionCheck,
+                                                                boolean includeHidden, String... magicServers) {
     return (ctx, builder) -> {
       String argument = ctx.getArguments().containsKey(argName)
           ? StringArgumentType.getString(ctx, argName)
@@ -78,25 +97,59 @@ public class CommandUtils {
 
       VelocityConfiguration.Queue queueConfig = server.getConfiguration().getQueue();
 
-      List<String> possibilities = server.getAllServers().stream()
-          .map(s -> s.getServerInfo().getName())
-          .filter(s -> allowNonQueueable || !queueConfig.isEnabled() || !queueConfig.getNoQueueServers().contains(s))
-          .collect(Collectors.toList());
+      for (VelocityRegisteredServer candidate : server.getAllServers()) {
+        String realName = candidate.getServerInfo().getName();
 
-      possibilities.addAll(Arrays.asList(magicServers));
-
-      for (String possibility : possibilities) {
-        if (possibility.regionMatches(true, 0, argument, 0, argument.length())) {
-          if (performPermissionCheck && ctx.getSource().getPermissionValue("velocity.command.server." + possibility) == Tristate.FALSE) {
-            continue;
-          }
-
-          builder.suggest(possibility);
+        if (!includeHidden && candidate.getServerInfo().isHiddenFromServerList()) {
+          continue;
         }
+
+        if (!allowNonQueueable && queueConfig.isEnabled()
+            && queueConfig.getNoQueueServers().contains(realName)) {
+          continue;
+        }
+
+        // Permissions are always keyed on the real server name, never the custom id.
+        if (performPermissionCheck
+            && ctx.getSource().getPermissionValue("velocity.command.server." + realName) == Tristate.FALSE) {
+          continue;
+        }
+
+        // Surface the custom id to players when configured, so the internal id stays hidden.
+        String token = publicServerId(candidate.getServerInfo());
+        if (token.regionMatches(true, 0, argument, 0, argument.length())) {
+          builder.suggest(token);
+        }
+      }
+
+      for (String magic : magicServers) {
+        if (!magic.regionMatches(true, 0, argument, 0, argument.length())) {
+          continue;
+        }
+
+        if (performPermissionCheck
+            && ctx.getSource().getPermissionValue("velocity.command.server." + magic) == Tristate.FALSE) {
+          continue;
+        }
+
+        builder.suggest(magic);
       }
 
       return builder.buildFuture();
     };
+  }
+
+  /**
+   * Returns the identifier that should be shown to players for the given server: its configured
+   * {@code custom-id} when present, otherwise its real name. The proxy resolves either form back to
+   * the same server, so this only affects what players see and type.
+   *
+   * @param info the server info
+   * @return the custom id if configured and non-blank, otherwise the real server name
+   */
+  public static String publicServerId(ServerInfo info) {
+    String customId = info.getCustomId();
+    return customId != null && !customId.isBlank() ? customId : info.getName();
   }
 
   /**

--- a/proxy/src/main/java/com/velocityctd/proxy/command/builtin/LeaveQueueCommand.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/command/builtin/LeaveQueueCommand.java
@@ -112,16 +112,17 @@ public class LeaveQueueCommand implements BuiltinCommandDefinition {
     }
 
     VelocityQueue<?> queue = this.server.getQueueManager().getQueue(registeredServer.getServerInfo().getName());
+    String display = registeredServer.getServerInfo().getDisplayName();
     if (queue.contains(player)) {
       queue.dequeue(player);
       player.sendMessage(
           Component.translatable("velocity.queue.command.left-queue")
-              .arguments(Component.text(registeredServer.getServerInfo().getName())));
+              .arguments(Component.text(display)));
       return SINGLE_SUCCESS;
     } else {
       player.sendMessage(
           Component.translatable("velocity.queue.error.not-in-queue")
-              .arguments(Component.text(registeredServer.getServerInfo().getName())));
+              .arguments(Component.text(display)));
       return 0;
     }
   }

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueue.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueue.java
@@ -70,6 +70,16 @@ public abstract class VelocityQueue<E extends VelocityQueueEntry> implements Que
     return backend.getServerInfo().getName();
   }
 
+  /**
+   * Returns the cosmetic name of this queue's backend server, to be shown to players in place of
+   * {@link #getName()}. Falls back to the server name when no display name is configured.
+   *
+   * @return the display name of the backend server
+   */
+  public String getDisplayName() {
+    return backend.getServerInfo().getDisplayName();
+  }
+
   @Override
   public VelocityRegisteredServer getServer() {
     return backend;

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueEntry.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueEntry.java
@@ -265,7 +265,7 @@ public class VelocityQueueEntry implements QueueEntry {
     if (attempts >= config.getMaxSendRetries()) {
       Component message = Component.translatable("velocity.queue.error.max-send-retries-reached")
           .arguments(
-              Component.text(this.queue.getName()),
+              Component.text(this.queue.getDisplayName()),
               Component.text(config.getMaxSendRetries()));
       this.server.getScheduler()
           .buildTask(VelocityVirtualPlugin.INSTANCE,

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/VelocityQueueManager.java
@@ -259,6 +259,7 @@ public class VelocityQueueManager implements QueueManager {
 
   public void queue(@NotNull ConnectedPlayer player, @NotNull VelocityRegisteredServer targetServer) {
     String targetName = targetServer.getServerInfo().getName();
+    String targetDisplay = targetServer.getServerInfo().getDisplayName();
     VelocityQueue<?> queue = getQueue(targetName);
 
     VelocityConfiguration.Queue config = server.getConfiguration().getQueue();
@@ -269,7 +270,7 @@ public class VelocityQueueManager implements QueueManager {
 
     if (queue.contains(player)) {
       player.sendMessage(Component.translatable("velocity.queue.error.already-queued")
-          .arguments(Component.text(targetName)));
+          .arguments(Component.text(targetDisplay)));
       return;
     }
 
@@ -279,8 +280,8 @@ public class VelocityQueueManager implements QueueManager {
           q.dequeue(player);
           player.sendMessage(Component.translatable("velocity.queue.error.queued-swap")
               .arguments(
-                  Argument.string("from", q.getName()),
-                  Argument.string("to", targetName)));
+                  Argument.string("from", q.getDisplayName()),
+                  Argument.string("to", targetDisplay)));
           break;
         }
       }
@@ -288,7 +289,7 @@ public class VelocityQueueManager implements QueueManager {
 
     if (queue.getState() == PAUSED && !config.isAllowPausedQueueJoining()) {
       player.sendMessage(Component.translatable("velocity.queue.error.paused")
-          .arguments(Component.text(targetName)));
+          .arguments(Component.text(targetDisplay)));
       return;
     }
 
@@ -298,7 +299,7 @@ public class VelocityQueueManager implements QueueManager {
 
     queue.enqueue(player);
     player.sendMessage(Component.translatable("velocity.queue.command.queued")
-        .arguments(Component.text(targetName)));
+        .arguments(Component.text(targetDisplay)));
 
     // If a queue-server is configured, move the player there if they aren't already on it
     String queueServerName = config.getQueueServer();

--- a/proxy/src/main/java/com/velocityctd/proxy/queue/util/QueueComponents.java
+++ b/proxy/src/main/java/com/velocityctd/proxy/queue/util/QueueComponents.java
@@ -53,11 +53,11 @@ public class QueueComponents {
           .arguments(
               Component.text(position),
               Component.text(queue.size()),
-              Component.text(queue.getName()),
+              Component.text(queue.getDisplayName()),
               formatEta(queue, position));
     } else if (entry.isWaitingForConnection()) {
       return Component.translatable("velocity.queue.player-status.connecting", NamedTextColor.YELLOW)
-          .arguments(Component.text(queue.getName()));
+          .arguments(Component.text(queue.getDisplayName()));
     } else if (queue.getState() == PAUSED) {
       return Component.translatable("velocity.queue.player-status.paused", NamedTextColor.YELLOW);
     } else if (queue.getServerStatus().isActive()) {
@@ -65,14 +65,14 @@ public class QueueComponents {
           .arguments(
               Component.text(position),
               Component.text(queue.size()),
-              Component.text(queue.getName()),
+              Component.text(queue.getDisplayName()),
               formatEta(queue, position));
     } else {
       return Component.translatable("velocity.queue.player-status.offline", NamedTextColor.YELLOW)
           .arguments(
               Component.text(position),
               Component.text(queue.size()),
-              Component.text(queue.getName()));
+              Component.text(queue.getDisplayName()));
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -417,7 +417,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
     if (!options.isIgnoreConfigServers()) {
       for (Map.Entry<String, BackendServerConfig> entry : configuration.getBackendServers().entrySet()) {
-        servers.register(new ServerInfo(entry.getKey(), AddressUtil.parseAddress(entry.getValue().address()), entry.getValue().forwardingMode()));
+        servers.register(toServerInfo(entry.getKey(), entry.getValue()));
       }
     }
 
@@ -796,12 +796,15 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     return aliases.toArray(String[]::new);
   }
 
+  private static ServerInfo toServerInfo(String name, BackendServerConfig config) {
+    return new ServerInfo(name, AddressUtil.parseAddress(config.address()), config.forwardingMode(),
+        config.displayName(), config.customId(), config.hiddenFromServerList());
+  }
+
   private void reconcileServers(VelocityConfiguration newConfiguration) {
     List<ServerInfo> desired = new ArrayList<>();
     for (Map.Entry<String, BackendServerConfig> entry : newConfiguration.getBackendServers().entrySet()) {
-      desired.add(new ServerInfo(entry.getKey(),
-          AddressUtil.parseAddress(entry.getValue().address()),
-          entry.getValue().forwardingMode()));
+      desired.add(toServerInfo(entry.getKey(), entry.getValue()));
     }
 
     // Servers registered now but absent from the new configuration: removed, renamed, or with a

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
@@ -84,7 +84,7 @@ public class ServerCommand implements BuiltinCommandDefinition {
           return SINGLE_SUCCESS;
         })
         .then(BrigadierCommand.requiredArgumentBuilder(SERVER_ARG, StringArgumentType.word())
-            .suggests(CommandUtils.suggestServer(server, SERVER_ARG, true, true))
+            .suggests(CommandUtils.suggestServer(server, SERVER_ARG, true, true, false))
             .executes(ctx -> {
               ConnectedPlayer player = (ConnectedPlayer) ctx.getSource();
               VelocityRegisteredServer registeredServer = CommandUtils.getServer(server, ctx, SERVER_ARG, true);
@@ -108,13 +108,15 @@ public class ServerCommand implements BuiltinCommandDefinition {
   }
 
   private static void outputServerInformation(ConnectedPlayer executor, VelocityServer server) {
-    String currentServer = executor.getCurrentServer()
+    ServerInfo currentServerInfo = executor.getCurrentServer()
         .map(VelocityServerConnection::getServerInfo)
-        .map(ServerInfo::getName)
-        .orElse("<unknown>");
+        .orElse(null);
+    String currentServerName = currentServerInfo != null ? currentServerInfo.getName() : null;
+    String currentServerDisplay = currentServerInfo != null
+        ? currentServerInfo.getDisplayName() : "<unknown>";
     executor.sendMessage(Component.translatable(
         "velocity.command.server-current-server", NamedTextColor.YELLOW)
-            .arguments(Component.text(currentServer)));
+            .arguments(Component.text(currentServerDisplay)));
 
     List<VelocityRegisteredServer> servers = CommandUtils.sortedServerList(server);
     if (servers.size() > MAX_SERVERS_TO_LIST) {
@@ -123,8 +125,9 @@ public class ServerCommand implements BuiltinCommandDefinition {
       return;
     }
 
-    // Filter servers based on player permissions
+    // Filter servers based on player permissions, hiding those marked hidden-from-server-list.
     List<VelocityRegisteredServer> accessibleServers = servers.stream()
+        .filter(rs -> !rs.getServerInfo().isHiddenFromServerList())
         .filter(rs -> executor.getPermissionValue("velocity.command.server."
             + rs.getServerInfo().getName()) != Tristate.FALSE)
         .toList();
@@ -141,7 +144,7 @@ public class ServerCommand implements BuiltinCommandDefinition {
         .appendSpace();
     for (int i = 0; i < accessibleServers.size(); i++) {
       VelocityRegisteredServer rs = accessibleServers.get(i);
-      serverListBuilder.append(formatServerComponent(currentServer, rs));
+      serverListBuilder.append(formatServerComponent(currentServerName, rs));
       if (i != accessibleServers.size() - 1) {
         serverListBuilder.append(Component.text(", ", NamedTextColor.GRAY));
       }
@@ -153,7 +156,7 @@ public class ServerCommand implements BuiltinCommandDefinition {
   private static TextComponent formatServerComponent(String currentPlayerServer, VelocityRegisteredServer server) {
     ServerInfo serverInfo = server.getServerInfo();
     TextComponent.Builder serverTextComponent = Component.text()
-            .content(serverInfo.getName());
+            .content(serverInfo.getDisplayName());
 
     int connectedPlayers = server.getPlayersConnected().size();
     TranslatableComponent.Builder playersTextComponent = Component.translatable();
@@ -173,7 +176,7 @@ public class ServerCommand implements BuiltinCommandDefinition {
           );
     } else {
       serverTextComponent.color(NamedTextColor.GRAY)
-          .clickEvent(ClickEvent.runCommand("/server " + serverInfo.getName()))
+          .clickEvent(ClickEvent.runCommand("/server " + CommandUtils.publicServerId(serverInfo)))
           .hoverEvent(
               showText(
                   Component.translatable("velocity.command.server-tooltip-offer-connect-server")

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -1600,6 +1600,9 @@ public final class VelocityConfiguration implements ProxyConfig {
           if (entry.getValue() instanceof CommentedConfig c) {
             String address = null;
             PlayerInfoForwarding forwardingMode = null;
+            String displayName = null;
+            String customId = null;
+            boolean hiddenFromServerList = false;
             for (UnmodifiableConfig.Entry entry2 : c.entrySet()) {
               if (entry2.getKey().equalsIgnoreCase("address")) {
                 address = entry2.getValue();
@@ -1618,13 +1621,26 @@ public final class VelocityConfiguration implements ProxyConfig {
               if (entry2.getKey().equalsIgnoreCase("maximum-version")) {
                 serverMaximumVersions.put(cleanValue(entry.getKey()), entry2.getValue());
               }
+
+              if (entry2.getKey().equalsIgnoreCase("display-name")) {
+                displayName = entry2.getValue();
+              }
+
+              if (entry2.getKey().equalsIgnoreCase("custom-id")) {
+                customId = cleanValue(entry2.getValue());
+              }
+
+              if (entry2.getKey().equalsIgnoreCase("hidden-from-server-list")) {
+                hiddenFromServerList = entry2.getValue();
+              }
             }
 
             if (address == null) {
               throw new IllegalArgumentException("Server entry " + entry.getKey() + " is missing address!");
             }
 
-            servers.put(cleanValue(entry.getKey()), new BackendServerConfig(address, forwardingMode));
+            servers.put(cleanValue(entry.getKey()),
+                new BackendServerConfig(address, forwardingMode, displayName, customId, hiddenFromServerList));
             // Support for old server config system (forwarding mode will be null)
           } else if (entry.getValue() instanceof String v) {
             servers.put(cleanValue(entry.getKey()), new BackendServerConfig(v));

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1003,7 +1003,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     Component friendlyError;
     if (connectedServer != null && connectedServer.getServerInfo().equals(server.getServerInfo())) {
       friendlyError = Component.translatable("velocity.error.connected-server-error",
-          Argument.string("server", server.getServerInfo().getName()));
+          Argument.string("server", server.getServerInfo().getDisplayName()));
     } else {
       if (Boolean.getBoolean("velocity.suppress-connection-timeout-logs")) {
         LOGGER.error("{}: unable to connect to server {}", this, server.getServerInfo().getName());
@@ -1012,7 +1012,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       }
 
       friendlyError = Component.translatable("velocity.error.connecting-server-error",
-          Argument.string("server", server.getServerInfo().getName()));
+          Argument.string("server", server.getServerInfo().getDisplayName()));
     }
 
     handleConnectionException(server, null, friendlyError.color(NamedTextColor.RED), safe);
@@ -1043,7 +1043,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       handleConnectionException(server, disconnectReason,
           Component.translatable("velocity.error.moved-to-new-server", NamedTextColor.RED)
               .arguments(
-                  Argument.string("server", server.getServerInfo().getName()),
+                  Argument.string("server", server.getServerInfo().getDisplayName()),
                   Argument.component("reason", disconnectReason)), safe);
     } else {
       if (this.server.getConfiguration().isLogPlayerConnections()) {
@@ -1054,7 +1054,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       handleConnectionException(server, disconnectReason,
           Component.translatable("velocity.error.cant-connect", NamedTextColor.RED)
               .arguments(
-                  Argument.string("server", server.getServerInfo().getName()),
+                  Argument.string("server", server.getServerInfo().getDisplayName()),
                   Argument.component("reason", disconnectReason)), safe);
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
@@ -39,20 +39,32 @@ public class ServerMap {
 
   private final Map<String, VelocityRegisteredServer> servers = new ConcurrentHashMap<>();
 
+  /**
+   * Maps configured {@code custom-id} aliases (lower-cased) to their registered server. A custom
+   * id lets players refer to a server by an alternate name in commands; the real server name always
+   * takes priority on lookup.
+   */
+  private final Map<String, VelocityRegisteredServer> customIds = new ConcurrentHashMap<>();
+
   public ServerMap(@Nullable VelocityServer server) {
     this.server = server;
   }
 
   /**
-   * Returns the server associated with the given name.
+   * Returns the server associated with the given name, or with a configured {@code custom-id}
+   * alias if no server has that exact name.
    *
-   * @param name the name to look up
+   * @param name the name or custom id to look up
    * @return the server, if it exists
    */
   public Optional<VelocityRegisteredServer> getServer(String name) {
     Preconditions.checkNotNull(name, "server");
     String lowerName = name.toLowerCase(Locale.US);
-    return Optional.ofNullable(servers.get(lowerName));
+    VelocityRegisteredServer registered = servers.get(lowerName);
+    if (registered == null) {
+      registered = customIds.get(lowerName);
+    }
+    return Optional.ofNullable(registered);
   }
 
   public Collection<VelocityRegisteredServer> getAllServers() {
@@ -86,6 +98,7 @@ public class ServerMap {
       throw new IllegalArgumentException(
           "Server with name " + serverInfo.getName() + " already registered");
     } else if (existing == null) {
+      registerCustomId(serverInfo, rs);
       if (server != null) {
         server.getEventManager().fireAndForget(new ServerRegisteredEvent(rs));
       }
@@ -94,6 +107,21 @@ public class ServerMap {
     } else {
       return existing;
     }
+  }
+
+  private void registerCustomId(ServerInfo serverInfo, VelocityRegisteredServer rs) {
+    String customId = serverInfo.getCustomId();
+    if (customId == null || customId.isBlank()) {
+      return;
+    }
+
+    String lowerCustomId = customId.toLowerCase(Locale.US);
+    // Never let a custom id shadow a real server name.
+    if (servers.containsKey(lowerCustomId)) {
+      return;
+    }
+
+    customIds.putIfAbsent(lowerCustomId, rs);
   }
 
   /**
@@ -114,6 +142,11 @@ public class ServerMap {
         "Trying to remove server %s with differing information", serverInfo.getName());
     Preconditions.checkState(servers.remove(lowerName, rs),
         "Server with name %s replaced whilst unregistering", serverInfo.getName());
+
+    String customId = serverInfo.getCustomId();
+    if (customId != null && !customId.isBlank()) {
+      customIds.remove(customId.toLowerCase(Locale.US), rs);
+    }
 
     if (server != null) {
       server.getEventManager().fireAndForget(new ServerUnregisteredEvent(rs));

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -191,11 +191,24 @@ bytes-per-second = -1
 decompressed-bytes-per-second = 5242880
 
 [servers]
-# Configure your servers here. Each key represents the server's name, and the value
-# represents the IP address of the server to connect to.
+# Configure your servers here. Each key represents the server's name (its internal id), and the
+# value is either the IP address of the server, or a table with per-server options:
+# - address:                 the IP address of the server to connect to (required in table form).
+# - forwarding-mode:         override the global player-info-forwarding-mode for this server.
+# - minimum-version / maximum-version: override the global version bounds for this server.
+# - display-name:            a cosmetic name shown to players wherever this server's name would be
+#                            displayed (the /server list, queue messages, etc.). The internal id is
+#                            unchanged.
+# - custom-id:               an extra name players may type in commands (e.g. /server bedwars) to
+#                            reach this server, in addition to its real id. The real id always wins.
+# - hidden-from-server-list: when true, the server is hidden from player-facing listings and
+#                            tab-completions (like /server), but still works normally for queues,
+#                            admin commands (/queueadmin, /send, ...) and direct connections by name.
 lobby = "127.0.0.1:30066"
 factions  = { address = "127.0.0.1:30067", forwarding-mode = "modern", minimum-version = "1.13" }
 minigames = { address = "127.0.0.1:30068", forwarding-mode = "legacy", minimum-version = "1.7.2", maximum-version = "1.21.10" }
+# Example using the display options:
+# bedwars-lobby = { address = "127.0.0.1:30069", display-name = "BedWars", custom-id = "bedwars", hidden-from-server-list = false }
 
 # In what order, we should try servers when a player logs in or is kicked from a server.
 try = [

--- a/proxy/src/test/java/com/velocitypowered/proxy/util/ServerMapTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/util/ServerMapTest.java
@@ -64,4 +64,39 @@ class ServerMapTest {
     VelocityRegisteredServer connection = map.register(info);
     assertEquals(connection, map.register(info));
   }
+
+  @Test
+  void resolvesServerByCustomId() {
+    ServerMap map = new ServerMap(null);
+    ServerInfo info = new ServerInfo("bedwars-lobby", TEST_ADDRESS, null, "BedWars", "bedwars", false);
+    VelocityRegisteredServer connection = map.register(info);
+
+    // Reachable by its real name...
+    assertEquals(Optional.of(connection), map.getServer("bedwars-lobby"));
+    // ...and by its custom id, case-insensitively.
+    assertEquals(Optional.of(connection), map.getServer("bedwars"));
+    assertEquals(Optional.of(connection), map.getServer("BEDWARS"));
+  }
+
+  @Test
+  void realServerNameTakesPriorityOverCustomId() {
+    ServerMap map = new ServerMap(null);
+    // "hub" is both a real server and another server's custom id.
+    ServerInfo hub = new ServerInfo("hub", TEST_ADDRESS);
+    ServerInfo other = new ServerInfo("lobby", TEST_ADDRESS, null, null, "hub", false);
+    VelocityRegisteredServer hubConnection = map.register(hub);
+    map.register(other);
+
+    assertEquals(Optional.of(hubConnection), map.getServer("hub"));
+  }
+
+  @Test
+  void customIdIsReleasedOnUnregister() {
+    ServerMap map = new ServerMap(null);
+    ServerInfo info = new ServerInfo("bedwars-lobby", TEST_ADDRESS, null, "BedWars", "bedwars", false);
+    map.register(info);
+    map.unregister(info);
+
+    assertEquals(Optional.empty(), map.getServer("bedwars"));
+  }
 }


### PR DESCRIPTION
This pull request introduces enhanced support for backend server metadata, allowing servers to have a cosmetic display name, an optional custom command identifier, and the ability to be hidden from player-facing listings. These features are integrated throughout the API and proxy, ensuring that commands, queues, and messages consistently use the new properties where appropriate.

**Backend Server Metadata Enhancements:**

* Added new fields to `BackendServerConfig` and `ServerInfo` to support a cosmetic `displayName`, a `customId` for command aliases, and a `hiddenFromServerList` flag to control server visibility in player-facing listings. [[1]](diffhunk://#diff-03f2152b05a84e007a1b892008370a13a1d6fae9c54937a8f75c22358a35c7f8R31-R78) [[2]](diffhunk://#diff-6ef80ef909ceef47dd73896d99acf7b55b584f0df4b1f5403fcbd1d4dd8dc202R38-R88)

* Updated constructors and accessors in `ServerInfo` to handle the new fields, including new methods `getDisplayName()`, `getCustomId()`, and `isHiddenFromServerList()`.

**Proxy Command and Queue Integration:**

* Modified command suggestion logic in `CommandUtils` to optionally exclude hidden servers and to suggest the public server identifier (custom ID if set, otherwise the real name) to players. Added `publicServerId()` utility for this purpose.

* Updated queue-related classes (`VelocityQueue`, `VelocityQueueManager`, `VelocityQueueEntry`, and `QueueComponents`) to use the server's display name in all player-facing messages and status components, improving clarity and consistency. [[1]](diffhunk://#diff-c2a5711752cffad934e9a71927e4dc303a811682214eff10e68c38fa780d0990R73-R82) [[2]](diffhunk://#diff-a1f5c57a9127003b6481911fa411ad6148754a384fc7e21652cd226f57868b0dL272-R273) [[3]](diffhunk://#diff-73d48f9ff4ec23815f90526914f5095cfb35daae169cfde96fe51dc690a8af4fL268-R268) [[4]](diffhunk://#diff-689e02faf0d0b17704f6e786acc6a2bff8c3a58fa8daa63435e5c5c0e1765766L56-R75)

**Configuration and Server Registration:**

* Refactored server registration in `VelocityServer` to use a helper method that constructs `ServerInfo` with the new metadata fields, ensuring all server instances are initialized with the enhanced metadata. [[1]](diffhunk://#diff-1217e64751ab6522195a858620cceeb4f2d2b6506c36dd4e396726ad3e7ef0cbL420-R420) [[2]](diffhunk://#diff-1217e64751ab6522195a858620cceeb4f2d2b6506c36dd4e396726ad3e7ef0cbR799-R807)Extend backend server metadata with `display-name`, `custom-id`, and `hidden-from-server-list`, and wire it through config parsing and `ServerInfo`. Player-facing commands/messages now use display names and public IDs, `/server` suggestions/listing hide flagged servers, and server lookup resolves custom IDs without overriding real names. Includes `ServerMap` tests for custom-id resolution, name-priority behavior, and alias cleanup on unregister.
---

### AI Assistance

This pull request was prepared with assistance from AI tools.  
Claude was used as a coding assistant during implementation, and GitHub Copilot was used to help generate this pull request description. All changes and generated content were reviewed by the author before submission.