### PR TITLE
Add configuration option for controlling access to "/velocity:callback".

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ dependencies, useful performance improvements, and more.
   to all users on the proxy or proxies, depending on your setup).
 * `velocity.command.alertraw` [/alertraw] (Allows you to display public non-formatted
   alerts to all users on the proxy or proxies, depending on your setup).
+* `velocity.command.callback` [/velocity:callback] (Controls execution of ClickEvent callbacks, depending on your configuration).
 * `velocity.command.find` [/find] (Allows you to find the specific server a user is
   actively connected to on the network).
 * `velocity.command.gkick` [/gkick] (Allows you to kick a player from the network,

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/CallbackCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/CallbackCommand.java
@@ -24,13 +24,17 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.adventure.ClickCallbackManager;
 import java.util.UUID;
 
 public class CallbackCommand implements BuiltinCommandDefinition {
 
+  private final VelocityServer server;
+
   public CallbackCommand(VelocityServer server) {
+    this.server = server;
   }
 
   @Override
@@ -42,6 +46,8 @@ public class CallbackCommand implements BuiltinCommandDefinition {
   public BrigadierCommand build() {
     LiteralCommandNode<CommandSource> node = BrigadierCommand
             .literalArgumentBuilder(label())
+            .requires(source -> !server.getConfiguration().isCallbackPermission()
+                    || source.getPermissionValue("velocity.command.callback") != Tristate.FALSE)
             .then(BrigadierCommand.requiredArgumentBuilder("id", StringArgumentType.word())
                     .executes(this::execute))
             .build();

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -750,6 +750,10 @@ public final class VelocityConfiguration implements ProxyConfig {
     return commands.isOverrideServerCommandUsage();
   }
 
+  public boolean isCallbackPermission() {
+    return commands.isCallbackPermission();
+  }
+
   @Override
   public int getReadTimeout() {
     return advanced.getReadTimeout();
@@ -1908,6 +1912,13 @@ public final class VelocityConfiguration implements ProxyConfig {
     @Expose
     private boolean transferEnabled = true;
 
+    /**
+     * Whether a permission node is used for the /velocity:callback command.
+     * Allows advanced users to control execution of ClickEvent callbacks.
+     */
+    @Expose
+    private boolean callbackPermission = true;
+
     private Commands() {
     }
 
@@ -1926,6 +1937,7 @@ public final class VelocityConfiguration implements ProxyConfig {
         this.sendCommand = config.getOrElse("send-enabled", true);
         this.overrideServerCommandUsage = config.getOrElse("override-server-command-usage", false);
         this.transferEnabled = config.getOrElse("transfer-enabled", true);
+        this.callbackPermission = config.getOrElse("callback-permission", false);
       }
     }
 
@@ -1981,6 +1993,10 @@ public final class VelocityConfiguration implements ProxyConfig {
       return transferEnabled;
     }
 
+    public boolean isCallbackPermission() {
+      return callbackPermission;
+    }
+
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
@@ -1997,6 +2013,7 @@ public final class VelocityConfiguration implements ProxyConfig {
           .add("sendCommand", sendCommand)
           .add("overrideServerCommandUsage", overrideServerCommandUsage)
           .add("transferEnabled", transferEnabled)
+          .add("callbackPermission", callbackPermission)
           .toString();
     }
   }


### PR DESCRIPTION
I'd like to suggest the addition of a "callback-permission" option to the configuration file.

This setting is designed to allow advanced users to control execution of the "/velocity:callback" command. To ensure compatibility, it is disabled by default. If it is enabled, a "velocity.command.callback" permission node becomes available.

By default, the permission node is set to "true". However, if an advanced user wants to disable "/velocity:callback" for a specific group/user in their permissions plugin, they can negatate the "velocity.command.callback" permission node.